### PR TITLE
fix(publish): publish from dist/ per Angular Package Format convention

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,6 @@ jobs:
         run: npm run build
 
       - name: Publish
-        run: npm publish
+        run: npm publish dist
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,8 @@ This is `@teqbench/tbx-ngx-http`, an Angular library providing base HTTP communi
 ## Publishing
 
 - Packages are published to GitHub Packages (`@teqbench` scope) via the release workflow.
-- `"files": ["dist"]` in `package.json` ensures only compiled output is included in the published package — source, tests, and config files are excluded.
 - Coverage thresholds are enforced in CI: 80% lines/functions/statements, 75% branches, per file.
-- **Build tooling:** ng-packagr is used to build Angular Package Format (APF) output. It uses bundler module resolution internally, so source files use extensionless relative imports (e.g., `'./foo.service'`). The `ng-package.json` at the repo root configures the entry point and output directory. ng-packagr generates its own `package.json` inside `dist/` with the correct APF entry points (`fesm2022/`, etc.), so the root `package.json` does not need `main`, `types`, or `exports` fields.
+- **Build tooling:** ng-packagr is used to build Angular Package Format (APF) output. It uses bundler module resolution internally, so source files use extensionless relative imports (e.g., `'./foo.service'`). The `ng-package.json` at the repo root configures the entry point and output directory. ng-packagr generates its own `package.json` inside `dist/` with the correct APF entry points (`module`, `types`, `exports`). The release workflow publishes from `dist/` (`npm publish dist`) so consumers resolve against ng-packagr's `package.json` directly — the root `package.json` does not need `main`, `types`, or `exports` fields.
 
 ## Commit Convention
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
   "engines": {
     "node": ">=24.0.0"
   },
-  "files": [
-    "dist"
-  ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },


### PR DESCRIPTION
## Summary

- Publish from `dist/` (`npm publish dist`) instead of root — standard Angular library practice
- Remove `"files": ["dist"]` from root `package.json` (no longer needed)
- Update CLAUDE.md publishing guidance to reflect the change

## Why

ng-packagr generates a complete `package.json` inside `dist/` with correct APF entry points (`module`, `types`, `exports`). Publishing from root caused consumers to resolve against the root `package.json` which lacked these fields, resulting in "Cannot find module" TypeScript errors.

## Test plan

- [x] `npm run build` — APF output correct, no warnings
- [x] `npm run lint` / `npm run typecheck` / `npm test` — all pass
- [x] `dist/package.json` has `types`, `module`, and `exports` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)