### PR TITLE
refactor(api): apply TbxNgx export naming convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance for Claude Code when working in this repository.
 
 ## Package Overview
 
-This is `@teqbench/tbx-ngx-http`, an Angular library providing base HTTP communication services and resilience constants. It offers an abstract `BaseHttpService` that feature services extend to get automatic retries with exponential backoff on GET requests, timeout handling, consistent URL resolution, and default headers. Resilience constants (`HTTP_DEFAULT_TIMEOUT_MS`, `HTTP_RETRY_COUNT`, `HTTP_RETRY_DELAY_MS`, `HTTP_RETRYABLE_STATUSES`) are exported for direct use.
+This is `@teqbench/tbx-ngx-http`, an Angular library providing base HTTP communication services and resilience constants. It offers an abstract `TbxNgxBaseHttpService` that feature services extend to get automatic retries with exponential backoff on GET requests, timeout handling, consistent URL resolution, and default headers. Resilience constants (`TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS`, `TBX_NGX_HTTP_RETRY_COUNT`, `TBX_NGX_HTTP_RETRY_DELAY_MS`, `TBX_NGX_HTTP_RETRYABLE_STATUSES`) are exported for direct use.
 
 ## Tech Stack
 
@@ -79,8 +79,8 @@ Follow **Conventional Commits** strictly:
 
 ## Package-Specific Guidance
 
-- `BaseHttpService` is abstract — it cannot be instantiated directly. Feature services extend it and provide a `baseUrl`.
+- `TbxNgxBaseHttpService` is abstract — it cannot be instantiated directly. Feature services extend it and provide a `baseUrl`.
 - Only GET requests include the retry operator. Mutating methods (POST, PUT, PATCH, DELETE) intentionally skip retries.
 - The retry operator uses exponential backoff: `RETRY_DELAY * 2^(attempt - 1)`.
-- `HTTP_RETRYABLE_STATUSES` defines which HTTP status codes trigger retries (0, 408, 429, 500, 502, 503, 504).
+- `TBX_NGX_HTTP_RETRYABLE_STATUSES` defines which HTTP status codes trigger retries (0, 408, 429, 500, 502, 503, 504).
 - Dependencies: `@angular/common` (HttpClient), `@angular/core` (inject), `rxjs`, `http-status-codes`.

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ npm install @teqbench/tbx-ngx-http
 
 ```typescript
 import { Injectable } from '@angular/core';
-import { BaseHttpService } from '@teqbench/tbx-ngx-http';
+import { TbxNgxBaseHttpService } from '@teqbench/tbx-ngx-http';
 import { environment } from '../environments/environment';
 
 @Injectable({ providedIn: 'root' })
-export class UserService extends BaseHttpService {
+export class UserService extends TbxNgxBaseHttpService {
     protected override readonly baseUrl = environment.apiUrl;
 
     getUser(id: string) {
@@ -41,26 +41,26 @@ export class UserService extends BaseHttpService {
 
 ## API Reference
 
-### `BaseHttpService` (abstract class)
+### `TbxNgxBaseHttpService` (abstract class)
 
 Abstract base class for feature services. Provides typed HTTP methods with built-in resilience.
 
-| Method   | Signature                                                                                | Retries |
-| -------- | ---------------------------------------------------------------------------------------- | ------- |
-| `get`    | `get<T>(path: string, options?: HttpRequestOptions): Observable<T>`                      | Yes     |
-| `post`   | `post<T>(path: string, body: unknown, options?: HttpBodyRequestOptions): Observable<T>`  | No      |
-| `put`    | `put<T>(path: string, body: unknown, options?: HttpBodyRequestOptions): Observable<T>`   | No      |
-| `patch`  | `patch<T>(path: string, body: unknown, options?: HttpBodyRequestOptions): Observable<T>` | No      |
-| `delete` | `delete<T>(path: string, options?: HttpRequestOptions): Observable<T>`                   | No      |
+| Method   | Signature                                                                                      | Retries |
+| -------- | ---------------------------------------------------------------------------------------------- | ------- |
+| `get`    | `get<T>(path: string, options?: TbxNgxHttpRequestOptions): Observable<T>`                      | Yes     |
+| `post`   | `post<T>(path: string, body: unknown, options?: TbxNgxHttpBodyRequestOptions): Observable<T>`  | No      |
+| `put`    | `put<T>(path: string, body: unknown, options?: TbxNgxHttpBodyRequestOptions): Observable<T>`   | No      |
+| `patch`  | `patch<T>(path: string, body: unknown, options?: TbxNgxHttpBodyRequestOptions): Observable<T>` | No      |
+| `delete` | `delete<T>(path: string, options?: TbxNgxHttpRequestOptions): Observable<T>`                   | No      |
 
 ### Constants
 
-| Constant                  | Default  | Description                                        |
-| ------------------------- | -------- | -------------------------------------------------- |
-| `HTTP_DEFAULT_TIMEOUT_MS` | `10_000` | Request timeout in milliseconds                    |
-| `HTTP_RETRY_COUNT`        | `2`      | Number of retry attempts for GET requests          |
-| `HTTP_RETRY_DELAY_MS`     | `1_000`  | Base delay for exponential backoff                 |
-| `HTTP_RETRYABLE_STATUSES` | `Set`    | Status codes eligible for retry (0, 408, 429, 5xx) |
+| Constant                          | Default  | Description                                        |
+| --------------------------------- | -------- | -------------------------------------------------- |
+| `TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS` | `10_000` | Request timeout in milliseconds                    |
+| `TBX_NGX_HTTP_RETRY_COUNT`        | `2`      | Number of retry attempts for GET requests          |
+| `TBX_NGX_HTTP_RETRY_DELAY_MS`     | `1_000`  | Base delay for exponential backoff                 |
+| `TBX_NGX_HTTP_RETRYABLE_STATUSES` | `Set`    | Status codes eligible for retry (0, 408, 429, 5xx) |
 
 ## Compatibility
 

--- a/src/constants/http.constants.ts
+++ b/src/constants/http.constants.ts
@@ -1,10 +1,10 @@
 import { StatusCodes } from 'http-status-codes';
 
 /**
- * HTTP resilience defaults for BaseHttpService.
+ * HTTP resilience defaults for TbxNgxBaseHttpService.
  *
  * These are the library-shipped defaults. Subclasses override behavior
- * by redeclaring the corresponding class property on BaseHttpService —
+ * by redeclaring the corresponding class property on TbxNgxBaseHttpService —
  * they do not need to import this file directly.
  *
  * Consuming apps that need to reference the defaults (e.g., in a custom
@@ -12,18 +12,18 @@ import { StatusCodes } from 'http-status-codes';
  *
  * @example
  * ```typescript
- * import { HTTP_DEFAULT_TIMEOUT_MS, HTTP_RETRYABLE_STATUSES } from '@teqbench/tbx-ngx-http';
+ * import { TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS, TBX_NGX_HTTP_RETRYABLE_STATUSES } from '@teqbench/tbx-ngx-http';
  * ```
  */
 
 /** Default request timeout in milliseconds. */
-export const HTTP_DEFAULT_TIMEOUT_MS = 10_000;
+export const TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS = 10_000;
 
 /** Number of retry attempts for idempotent requests (GET only). */
-export const HTTP_RETRY_COUNT = 2;
+export const TBX_NGX_HTTP_RETRY_COUNT = 2;
 
 /** Base delay in milliseconds for exponential backoff between retries. */
-export const HTTP_RETRY_DELAY_MS = 1_000;
+export const TBX_NGX_HTTP_RETRY_DELAY_MS = 1_000;
 
 /**
  * HTTP status codes eligible for automatic retry.
@@ -40,7 +40,7 @@ export const HTTP_RETRY_DELAY_MS = 1_000;
  * - `503` — Service Unavailable (server temporarily overloaded or in maintenance)
  * - `504` — Gateway Timeout (upstream server did not respond in time)
  */
-export const HTTP_RETRYABLE_STATUSES = new Set([
+export const TBX_NGX_HTTP_RETRYABLE_STATUSES = new Set([
     0, // Network error — no HTTP standard; browser-specific status when no response is received
     StatusCodes.REQUEST_TIMEOUT,
     StatusCodes.TOO_MANY_REQUESTS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
  */
 export * from './constants/http.constants';
 export {
-    BaseHttpService,
-    type HttpRequestOptions,
-    type HttpBodyRequestOptions,
+    TbxNgxBaseHttpService,
+    type TbxNgxHttpRequestOptions,
+    type TbxNgxHttpBodyRequestOptions,
 } from './services/base-http.service';

--- a/src/services/base-http.service.spec.ts
+++ b/src/services/base-http.service.spec.ts
@@ -5,38 +5,38 @@ import { Injectable } from '@angular/core';
 import { Observable, of, catchError, firstValueFrom } from 'rxjs';
 import { StatusCodes, ReasonPhrases } from 'http-status-codes';
 
-import { BaseHttpService } from './base-http.service';
-import type { HttpRequestOptions, HttpBodyRequestOptions } from './base-http.service';
+import { TbxNgxBaseHttpService } from './base-http.service';
+import type { TbxNgxHttpRequestOptions, TbxNgxHttpBodyRequestOptions } from './base-http.service';
 import {
-    HTTP_DEFAULT_TIMEOUT_MS,
-    HTTP_RETRY_COUNT,
-    HTTP_RETRY_DELAY_MS,
+    TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS,
+    TBX_NGX_HTTP_RETRY_COUNT,
+    TBX_NGX_HTTP_RETRY_DELAY_MS,
 } from '../constants/http.constants';
 
 const TEST_BASE_URL = 'https://api.test.com';
 
 /**
- * Concrete test harness that exposes BaseHttpService's protected methods.
+ * Concrete test harness that exposes TbxNgxBaseHttpService's protected methods.
  * Each public method delegates directly to the corresponding base method
  * with the same signature, adding no logic of its own.
  */
 @Injectable()
-class TestDataService extends BaseHttpService {
+class TestDataService extends TbxNgxBaseHttpService {
     protected override readonly baseUrl = TEST_BASE_URL;
 
-    public testGet(options?: HttpRequestOptions) {
+    public testGet(options?: TbxNgxHttpRequestOptions) {
         return this.get<{ success: boolean }>('test', options);
     }
-    public testPost(body: unknown, options?: HttpBodyRequestOptions) {
+    public testPost(body: unknown, options?: TbxNgxHttpBodyRequestOptions) {
         return this.post<{ success: boolean }>('test', body, options);
     }
-    public testPut(body: unknown, options?: HttpBodyRequestOptions) {
+    public testPut(body: unknown, options?: TbxNgxHttpBodyRequestOptions) {
         return this.put<{ success: boolean }>('test', body, options);
     }
-    public testPatch(body: unknown, options?: HttpBodyRequestOptions) {
+    public testPatch(body: unknown, options?: TbxNgxHttpBodyRequestOptions) {
         return this.patch<{ success: boolean }>('test', body, options);
     }
-    public testDelete(options?: HttpRequestOptions) {
+    public testDelete(options?: TbxNgxHttpRequestOptions) {
         return this.delete<{ success: boolean }>('test', options);
     }
 }
@@ -50,10 +50,10 @@ class TestDataService extends BaseHttpService {
  * for multi-cycle retry verification.
  *
  * This also validates the subclass override pattern documented in
- * BaseHttpService's JSDoc.
+ * TbxNgxBaseHttpService's JSDoc.
  */
 @Injectable()
-class RetryTestService extends BaseHttpService {
+class RetryTestService extends TbxNgxBaseHttpService {
     protected override readonly baseUrl = TEST_BASE_URL;
     protected override readonly RETRY_DELAY = 0;
 
@@ -67,7 +67,7 @@ class RetryTestService extends BaseHttpService {
  * Variant with a trailing-slash baseUrl to verify URL normalization.
  */
 @Injectable()
-class TrailingSlashService extends BaseHttpService {
+class TrailingSlashService extends TbxNgxBaseHttpService {
     protected override readonly baseUrl = `${TEST_BASE_URL}/`;
 
     public testGet(path: string) {
@@ -77,7 +77,7 @@ class TrailingSlashService extends BaseHttpService {
 
 const TEST_URL = `${TEST_BASE_URL}/test`;
 
-describe('BaseHttpService', () => {
+describe('TbxNgxBaseHttpService', () => {
     let service: TestDataService;
     let httpMock: HttpTestingController;
 
@@ -103,16 +103,16 @@ describe('BaseHttpService', () => {
     // ── Constants alignment ────────────────────────────────────────────────
 
     describe('Constants alignment', () => {
-        it('should source DEFAULT_TIMEOUT from HTTP_DEFAULT_TIMEOUT_MS', () => {
-            expect(service['DEFAULT_TIMEOUT']).toBe(HTTP_DEFAULT_TIMEOUT_MS);
+        it('should source DEFAULT_TIMEOUT from TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS', () => {
+            expect(service['DEFAULT_TIMEOUT']).toBe(TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS);
         });
 
-        it('should source RETRY_COUNT from HTTP_RETRY_COUNT', () => {
-            expect(service['RETRY_COUNT']).toBe(HTTP_RETRY_COUNT);
+        it('should source RETRY_COUNT from TBX_NGX_HTTP_RETRY_COUNT', () => {
+            expect(service['RETRY_COUNT']).toBe(TBX_NGX_HTTP_RETRY_COUNT);
         });
 
-        it('should source RETRY_DELAY from HTTP_RETRY_DELAY_MS', () => {
-            expect(service['RETRY_DELAY']).toBe(HTTP_RETRY_DELAY_MS);
+        it('should source RETRY_DELAY from TBX_NGX_HTTP_RETRY_DELAY_MS', () => {
+            expect(service['RETRY_DELAY']).toBe(TBX_NGX_HTTP_RETRY_DELAY_MS);
         });
     });
 
@@ -314,7 +314,7 @@ describe('BaseHttpService', () => {
             );
 
             // 1 initial + 2 retries = 3 total attempts
-            expect(attempts).toBe(HTTP_RETRY_COUNT + 1);
+            expect(attempts).toBe(TBX_NGX_HTTP_RETRY_COUNT + 1);
         });
 
         it('should NOT retry non-retryable errors (4xx)', async () => {
@@ -492,7 +492,7 @@ describe('BaseHttpService', () => {
                     statusText: ReasonPhrases.BAD_GATEWAY,
                 });
 
-                vi.advanceTimersByTime(HTTP_RETRY_DELAY_MS);
+                vi.advanceTimersByTime(TBX_NGX_HTTP_RETRY_DELAY_MS);
                 const retry = httpMock.expectOne(TEST_URL);
                 retry.flush({ success: true });
             });
@@ -505,7 +505,7 @@ describe('BaseHttpService', () => {
                     statusText: ReasonPhrases.SERVICE_UNAVAILABLE,
                 });
 
-                vi.advanceTimersByTime(HTTP_RETRY_DELAY_MS);
+                vi.advanceTimersByTime(TBX_NGX_HTTP_RETRY_DELAY_MS);
                 httpMock.expectOne(TEST_URL).flush({ success: true });
             });
 
@@ -517,7 +517,7 @@ describe('BaseHttpService', () => {
                     statusText: ReasonPhrases.GATEWAY_TIMEOUT,
                 });
 
-                vi.advanceTimersByTime(HTTP_RETRY_DELAY_MS);
+                vi.advanceTimersByTime(TBX_NGX_HTTP_RETRY_DELAY_MS);
                 httpMock.expectOne(TEST_URL).flush({ success: true });
             });
 
@@ -529,7 +529,7 @@ describe('BaseHttpService', () => {
                     statusText: ReasonPhrases.REQUEST_TIMEOUT,
                 });
 
-                vi.advanceTimersByTime(HTTP_RETRY_DELAY_MS);
+                vi.advanceTimersByTime(TBX_NGX_HTTP_RETRY_DELAY_MS);
                 httpMock.expectOne(TEST_URL).flush({ success: true });
             });
 
@@ -541,7 +541,7 @@ describe('BaseHttpService', () => {
                     statusText: ReasonPhrases.TOO_MANY_REQUESTS,
                 });
 
-                vi.advanceTimersByTime(HTTP_RETRY_DELAY_MS);
+                vi.advanceTimersByTime(TBX_NGX_HTTP_RETRY_DELAY_MS);
                 httpMock.expectOne(TEST_URL).flush({ success: true });
             });
 
@@ -550,7 +550,7 @@ describe('BaseHttpService', () => {
 
                 httpMock.expectOne(TEST_URL).error(new ProgressEvent('error'));
 
-                vi.advanceTimersByTime(HTTP_RETRY_DELAY_MS);
+                vi.advanceTimersByTime(TBX_NGX_HTTP_RETRY_DELAY_MS);
                 httpMock.expectOne(TEST_URL).flush({ success: true });
             });
         });
@@ -565,7 +565,7 @@ describe('BaseHttpService', () => {
                     statusText: ReasonPhrases.BAD_REQUEST,
                 });
 
-                vi.advanceTimersByTime(HTTP_RETRY_DELAY_MS * 10);
+                vi.advanceTimersByTime(TBX_NGX_HTTP_RETRY_DELAY_MS * 10);
                 httpMock.expectNone(TEST_URL);
                 expect(error).toBeDefined();
             });
@@ -579,7 +579,7 @@ describe('BaseHttpService', () => {
                     statusText: ReasonPhrases.UNAUTHORIZED,
                 });
 
-                vi.advanceTimersByTime(HTTP_RETRY_DELAY_MS * 10);
+                vi.advanceTimersByTime(TBX_NGX_HTTP_RETRY_DELAY_MS * 10);
                 httpMock.expectNone(TEST_URL);
                 expect(error).toBeDefined();
             });
@@ -593,7 +593,7 @@ describe('BaseHttpService', () => {
                     statusText: ReasonPhrases.FORBIDDEN,
                 });
 
-                vi.advanceTimersByTime(HTTP_RETRY_DELAY_MS * 10);
+                vi.advanceTimersByTime(TBX_NGX_HTTP_RETRY_DELAY_MS * 10);
                 httpMock.expectNone(TEST_URL);
                 expect(error).toBeDefined();
             });
@@ -607,7 +607,7 @@ describe('BaseHttpService', () => {
                     statusText: ReasonPhrases.NOT_FOUND,
                 });
 
-                vi.advanceTimersByTime(HTTP_RETRY_DELAY_MS * 10);
+                vi.advanceTimersByTime(TBX_NGX_HTTP_RETRY_DELAY_MS * 10);
                 httpMock.expectNone(TEST_URL);
                 expect(error).toBeDefined();
             });
@@ -633,7 +633,7 @@ describe('BaseHttpService', () => {
             httpMock.expectOne(TEST_URL);
 
             // Advance past the timeout threshold
-            vi.advanceTimersByTime(HTTP_DEFAULT_TIMEOUT_MS + 1);
+            vi.advanceTimersByTime(TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS + 1);
 
             expect(error).toBeDefined();
             expect((error as Error).name).toBe('TimeoutError');
@@ -673,7 +673,7 @@ describe('BaseHttpService', () => {
                 statusText: ReasonPhrases.INTERNAL_SERVER_ERROR,
             });
 
-            vi.advanceTimersByTime(HTTP_RETRY_DELAY_MS * 10);
+            vi.advanceTimersByTime(TBX_NGX_HTTP_RETRY_DELAY_MS * 10);
             httpMock.expectNone(TEST_URL);
             expect(error).toBeDefined();
         });
@@ -687,7 +687,7 @@ describe('BaseHttpService', () => {
                 statusText: ReasonPhrases.INTERNAL_SERVER_ERROR,
             });
 
-            vi.advanceTimersByTime(HTTP_RETRY_DELAY_MS * 10);
+            vi.advanceTimersByTime(TBX_NGX_HTTP_RETRY_DELAY_MS * 10);
             httpMock.expectNone(TEST_URL);
             expect(error).toBeDefined();
         });
@@ -701,7 +701,7 @@ describe('BaseHttpService', () => {
                 statusText: ReasonPhrases.INTERNAL_SERVER_ERROR,
             });
 
-            vi.advanceTimersByTime(HTTP_RETRY_DELAY_MS * 10);
+            vi.advanceTimersByTime(TBX_NGX_HTTP_RETRY_DELAY_MS * 10);
             httpMock.expectNone(TEST_URL);
             expect(error).toBeDefined();
         });
@@ -715,7 +715,7 @@ describe('BaseHttpService', () => {
                 statusText: ReasonPhrases.INTERNAL_SERVER_ERROR,
             });
 
-            vi.advanceTimersByTime(HTTP_RETRY_DELAY_MS * 10);
+            vi.advanceTimersByTime(TBX_NGX_HTTP_RETRY_DELAY_MS * 10);
             httpMock.expectNone(TEST_URL);
             expect(error).toBeDefined();
         });

--- a/src/services/base-http.service.ts
+++ b/src/services/base-http.service.ts
@@ -3,20 +3,20 @@ import { inject } from '@angular/core';
 import { Observable, retry, throwError, timer, timeout } from 'rxjs';
 
 import {
-    HTTP_DEFAULT_TIMEOUT_MS,
-    HTTP_RETRY_COUNT,
-    HTTP_RETRY_DELAY_MS,
-    HTTP_RETRYABLE_STATUSES,
+    TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS,
+    TBX_NGX_HTTP_RETRY_COUNT,
+    TBX_NGX_HTTP_RETRY_DELAY_MS,
+    TBX_NGX_HTTP_RETRYABLE_STATUSES,
 } from '../constants/http.constants';
 
 /** Options accepted by non-body methods (GET, DELETE). */
-export interface HttpRequestOptions {
+export interface TbxNgxHttpRequestOptions {
     params?: HttpParams;
     headers?: HttpHeaders;
 }
 
 /** Options accepted by body methods (POST, PUT, PATCH). */
-export interface HttpBodyRequestOptions {
+export interface TbxNgxHttpBodyRequestOptions {
     headers?: HttpHeaders;
 }
 
@@ -32,7 +32,7 @@ export interface HttpBodyRequestOptions {
  * @example
  * ```typescript
  * @Injectable({ providedIn: 'root' })
- * export class UserService extends BaseHttpService {
+ * export class UserService extends TbxNgxBaseHttpService {
  *     protected override readonly baseUrl = environment.apiUrl;
  *
  *     getUser(id: string) {
@@ -45,13 +45,13 @@ export interface HttpBodyRequestOptions {
  *
  * @example
  * ```typescript
- * export class SlowApiService extends BaseHttpService {
+ * export class SlowApiService extends TbxNgxBaseHttpService {
  *     protected override readonly baseUrl = environment.apiUrl;
  *     protected override readonly DEFAULT_TIMEOUT = 30_000;
  * }
  * ```
  */
-export abstract class BaseHttpService {
+export abstract class TbxNgxBaseHttpService {
     protected readonly http = inject(HttpClient);
 
     /** Base API URL — must be provided by the consuming application. */
@@ -62,9 +62,9 @@ export abstract class BaseHttpService {
      * Subclasses override by redeclaring the property; they do not need
      * to import the constants file directly.
      */
-    protected readonly DEFAULT_TIMEOUT: number = HTTP_DEFAULT_TIMEOUT_MS;
-    protected readonly RETRY_COUNT: number = HTTP_RETRY_COUNT;
-    protected readonly RETRY_DELAY: number = HTTP_RETRY_DELAY_MS;
+    protected readonly DEFAULT_TIMEOUT: number = TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS;
+    protected readonly RETRY_COUNT: number = TBX_NGX_HTTP_RETRY_COUNT;
+    protected readonly RETRY_DELAY: number = TBX_NGX_HTTP_RETRY_DELAY_MS;
 
     /**
      * Default headers applied to every request unless overridden per-call.
@@ -87,7 +87,7 @@ export abstract class BaseHttpService {
      * Includes retries with exponential backoff because GET is idempotent
      * and safe to repeat on transient failure (5xx, network errors).
      */
-    protected get<T>(path: string, options?: HttpRequestOptions): Observable<T> {
+    protected get<T>(path: string, options?: TbxNgxHttpRequestOptions): Observable<T> {
         return this.http
             .get<T>(this.url(path), {
                 params: options?.params,
@@ -103,7 +103,7 @@ export abstract class BaseHttpService {
     protected post<T>(
         path: string,
         body: unknown,
-        options?: HttpBodyRequestOptions
+        options?: TbxNgxHttpBodyRequestOptions
     ): Observable<T> {
         return this.http
             .post<T>(this.url(path), body, {
@@ -117,7 +117,11 @@ export abstract class BaseHttpService {
      * Retries are disabled by default to maintain strict idempotency safety
      * across varying backend implementations.
      */
-    protected put<T>(path: string, body: unknown, options?: HttpBodyRequestOptions): Observable<T> {
+    protected put<T>(
+        path: string,
+        body: unknown,
+        options?: TbxNgxHttpBodyRequestOptions
+    ): Observable<T> {
         return this.http
             .put<T>(this.url(path), body, {
                 headers: options?.headers ?? this.defaultHeaders,
@@ -132,7 +136,7 @@ export abstract class BaseHttpService {
     protected patch<T>(
         path: string,
         body: unknown,
-        options?: HttpBodyRequestOptions
+        options?: TbxNgxHttpBodyRequestOptions
     ): Observable<T> {
         return this.http
             .patch<T>(this.url(path), body, {
@@ -146,7 +150,7 @@ export abstract class BaseHttpService {
      * Retries are disabled to avoid 404/410 errors on subsequent automated
      * attempts if the first request actually succeeded but the response was lost.
      */
-    protected delete<T>(path: string, options?: HttpRequestOptions): Observable<T> {
+    protected delete<T>(path: string, options?: TbxNgxHttpRequestOptions): Observable<T> {
         return this.http
             .delete<T>(this.url(path), {
                 params: options?.params,
@@ -162,7 +166,7 @@ export abstract class BaseHttpService {
 
     /**
      * Returns a custom RxJS operator configured with exponential backoff that
-     * only retries transient errors (status codes in HTTP_RETRYABLE_STATUSES).
+     * only retries transient errors (status codes in TBX_NGX_HTTP_RETRYABLE_STATUSES).
      *
      * Non-retryable errors (4xx client errors except 408/429) are re-thrown
      * immediately — repeating a malformed request will not produce a
@@ -193,7 +197,7 @@ export abstract class BaseHttpService {
                     delay: (error: unknown, attempt: number) => {
                         if (
                             error instanceof HttpErrorResponse &&
-                            !HTTP_RETRYABLE_STATUSES.has(error.status)
+                            !TBX_NGX_HTTP_RETRYABLE_STATUSES.has(error.status)
                         ) {
                             return throwError(() => error);
                         }


### PR DESCRIPTION
## Summary
- Prefixed all public exports with `TbxNgx` (PascalCase) / `TBX_NGX_` (UPPER_SNAKE_CASE) to align with the @teqbench standardized naming convention
- Updated source files, tests, barrel file, README, and CLAUDE.md
- All 47 tests pass, typecheck clean

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — all 47 tests pass
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)