### PR TITLE
refactor(http): extract interfaces and add TSDoc documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,13 @@ This is `@teqbench/tbx-ngx-http`, an Angular library providing base HTTP communi
 
 ## Tech Stack
 
-- **Language:** TypeScript 5.9+ (strict mode, ES2022 target, bundler module resolution)
-- **Testing:** Vitest (globals enabled)
-- **Linting:** ESLint flat config with typescript-eslint
-- **Formatting:** Prettier (enforced via pre-commit hook and CI)
-- **Git Hooks:** Husky + lint-staged
-- **Versioning:** Release Please (Conventional Commits)
-- **Registry:** GitHub Packages (`@teqbench` scope)
+- **Language:** [TypeScript ↗](https://www.typescriptlang.org/) 5.9+ (strict mode, [ES2022 ↗](https://262.ecma-international.org/13.0/) target, bundler module resolution)
+- **Testing:** [Vitest ↗](https://vitest.dev/) (globals enabled)
+- **Linting:** [ESLint ↗](https://eslint.org/) flat config with typescript-eslint
+- **Formatting:** [Prettier ↗](https://prettier.io/) (enforced via pre-commit hook and CI)
+- **Git Hooks:** [Husky ↗](https://typicode.github.io/husky/) + [lint-staged ↗](https://github.com/okonet/lint-staged)
+- **Versioning:** [Release Please ↗](https://github.com/googleapis/release-please) ([Conventional Commits ↗](https://conventionalcommits.org/))
+- **Registry:** [GitHub Packages ↗](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages) (`@teqbench` scope)
 
 ## Key Commands
 
@@ -40,11 +40,11 @@ This is `@teqbench/tbx-ngx-http`, an Angular library providing base HTTP communi
 
 - Packages are published to GitHub Packages (`@teqbench` scope) via the release workflow.
 - Coverage thresholds are enforced in CI: 80% lines/functions/statements, 75% branches, per file.
-- **Build tooling:** ng-packagr is used to build Angular Package Format (APF) output. It uses bundler module resolution internally, so source files use extensionless relative imports (e.g., `'./foo.service'`). The `ng-package.json` at the repo root configures the entry point and output directory. ng-packagr generates its own `package.json` inside `dist/` with the correct APF entry points (`module`, `types`, `exports`). The release workflow publishes from `dist/` (`npm publish ./dist`) so consumers resolve against ng-packagr's `package.json` directly — the root `package.json` does not need `main`, `types`, or `exports` fields.
+- **Build tooling:** [ng-packagr ↗](https://github.com/ng-packagr/ng-packagr) is used to build [Angular Package Format ↗](https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/edit) (APF) output. It uses bundler module resolution internally, so source files use extensionless relative imports (e.g., `'./foo.service'`). The `ng-package.json` at the repo root configures the entry point and output directory. ng-packagr generates its own `package.json` inside `dist/` with the correct APF entry points (`module`, `types`, `exports`). The release workflow publishes from `dist/` (`npm publish ./dist`) so consumers resolve against ng-packagr's `package.json` directly — the root `package.json` does not need `main`, `types`, or `exports` fields.
 
-## TSDoc Convention
+## [TSDoc ↗](https://tsdoc.org/) Convention
 
-All exported TypeScript declarations must have TSDoc comments validated by `eslint-plugin-tsdoc`. Custom tags are defined in `tsdoc.json` and consumed downstream by API Extractor and the AI HTML documentation generator.
+All exported TypeScript declarations must have TSDoc comments validated by `eslint-plugin-tsdoc`. Custom tags are defined in `tsdoc.json` and consumed downstream by [API Extractor ↗](https://api-extractor.com/) and the AI HTML documentation generator.
 
 ### Standard Tags (always use)
 
@@ -147,7 +147,7 @@ Members (properties, methods): summary line → `@remarks` → `@param` / `@retu
 
 ## Commit Convention
 
-Follow **Conventional Commits** strictly:
+Follow **[Conventional Commits ↗](https://conventionalcommits.org/)** strictly:
 
 - `feat(scope): ...` — New feature (minor bump)
 - `fix(scope): ...` — Bug fix (patch bump)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance for Claude Code when working in this repository.
 
 ## Package Overview
 
-This is `@teqbench/tbx-ngx-http`, an Angular library providing base HTTP communication services and resilience constants. It offers an abstract `TbxNgxBaseHttpService` that feature services extend to get automatic retries with exponential backoff on GET requests, timeout handling, consistent URL resolution, and default headers. Resilience constants (`TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS`, `TBX_NGX_HTTP_RETRY_COUNT`, `TBX_NGX_HTTP_RETRY_DELAY_MS`, `TBX_NGX_HTTP_RETRYABLE_STATUSES`) are exported for direct use.
+This is `@teqbench/tbx-ngx-http`, an Angular library providing base HTTP communication services and resilience constants. It offers an abstract `TbxNgxHttpService` that feature services extend to get automatic retries with exponential backoff on GET requests, timeout handling, consistent URL resolution, and default headers. Resilience constants (`TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS`, `TBX_NGX_HTTP_RETRY_COUNT`, `TBX_NGX_HTTP_RETRY_DELAY_MS`, `TBX_NGX_HTTP_RETRYABLE_STATUSES`) are exported for direct use.
 
 ## Tech Stack
 
@@ -182,7 +182,7 @@ Follow **Conventional Commits** strictly:
 
 ## Package-Specific Guidance
 
-- `TbxNgxBaseHttpService` is abstract — it cannot be instantiated directly. Feature services extend it and provide a `baseUrl`.
+- `TbxNgxHttpService` is abstract — it cannot be instantiated directly. Feature services extend it and provide a `baseUrl`.
 - Only GET requests include the retry operator. Mutating methods (POST, PUT, PATCH, DELETE) intentionally skip retries.
 - The retry operator uses exponential backoff: `RETRY_DELAY * 2^(attempt - 1)`.
 - `TBX_NGX_HTTP_RETRYABLE_STATUSES` defines which HTTP status codes trigger retries (0, 408, 429, 500, 502, 503, 504).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This is `@teqbench/tbx-ngx-http`, an Angular library providing base HTTP communi
 - **Formatting:** [Prettier ↗](https://prettier.io/) (enforced via pre-commit hook and CI)
 - **Git Hooks:** [Husky ↗](https://typicode.github.io/husky/) + [lint-staged ↗](https://github.com/okonet/lint-staged)
 - **Versioning:** [Release Please ↗](https://github.com/googleapis/release-please) ([Conventional Commits ↗](https://conventionalcommits.org/))
-- **Registry:** [GitHub Packages ↗](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages) (`@teqbench` scope)
+- **Registry:** [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) (`@teqbench` scope)
 
 ## Key Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,109 @@ This is `@teqbench/tbx-ngx-http`, an Angular library providing base HTTP communi
 - Coverage thresholds are enforced in CI: 80% lines/functions/statements, 75% branches, per file.
 - **Build tooling:** ng-packagr is used to build Angular Package Format (APF) output. It uses bundler module resolution internally, so source files use extensionless relative imports (e.g., `'./foo.service'`). The `ng-package.json` at the repo root configures the entry point and output directory. ng-packagr generates its own `package.json` inside `dist/` with the correct APF entry points (`module`, `types`, `exports`). The release workflow publishes from `dist/` (`npm publish ./dist`) so consumers resolve against ng-packagr's `package.json` directly — the root `package.json` does not need `main`, `types`, or `exports` fields.
 
+## TSDoc Convention
+
+All exported TypeScript declarations must have TSDoc comments validated by `eslint-plugin-tsdoc`. Custom tags are defined in `tsdoc.json` and consumed downstream by API Extractor and the AI HTML documentation generator.
+
+### Standard Tags (always use)
+
+- `@remarks` — Extended description, separated from the summary line.
+- `@typeParam` — Document generic type parameters (not `@template`).
+- `@param` — Document function/method parameters.
+- `@returns` — Document return values.
+- `@example` — Code examples in fenced TypeScript blocks.
+- `@public` / `@internal` — Release tag on every export. Use `@public` unless the export is not part of the package API surface.
+- `@packageDocumentation` — Required on every barrel file (`index.ts`) to describe the package entry point. Use `{@link ExportName}` to cross-reference primary exports.
+- `@see` — Reference to related external resources or docs.
+- `@deprecated` — Mark deprecated APIs with migration guidance.
+
+### Custom Tags
+
+- `@category` — Group exports by domain for navigation and table-of-contents generation (e.g., "Models", "Services", "Utilities", "Pipes", "Guards"). Repeatable — an export can belong to multiple categories (e.g., "Models", "Foundational", "Interface").
+- `@since` — The package version when the export was first introduced (e.g., "1.0.0"). Allows the docs generator to render version badges and filter by release.
+- `@related` — Cross-reference to a related export, optionally in another `@teqbench` package (e.g., "TbxAuthService" or "@teqbench/tbx-auth#TbxAuthService"). Repeatable — use one `@related` tag per reference.
+- `@usage` — Prose description of when and why to use this export, distinct from `@example` which shows code. Helps the AI generator produce contextual KB articles rather than raw API listings.
+- `@displayName` — Human-friendly label used as the heading in generated docs (e.g., "Base Model" for `TbxModel`). When omitted, the export name is used as-is.
+- `@order` — Numeric sort hint controlling display sequence. Applied at two levels:
+    - Top-level exports: controls display sequence within a `@category` on generated pages.
+    - Members (properties, methods): controls display sequence within the parent class/interface page. Members without `@order` are sorted by precedence group (see Member Ordering below), then alphabetically.
+
+### Member Ordering
+
+The documentation generator groups and sorts members within a class or interface page using the following precedence. Within each group, members are sorted by `@order` (lowest first), then alphabetically.
+
+1. Constructor(s)
+2. Identity properties (named `id`)
+3. Required readonly properties
+4. Required mutable properties
+5. Optional properties
+6. Abstract methods
+7. Public methods
+8. Protected methods
+9. Static members
+10. Events / callbacks
+11. Deprecated members
+
+Add `@order` to any member where alphabetical sorting within its group produces the wrong result. Common cases:
+
+- `id` should appear before `createdAt` and `updatedAt` — give `id` `@order 1`.
+- Lifecycle-related properties should appear in logical sequence — use `@order` to enforce creation-before-update ordering.
+
+### Comment Structure
+
+Top-level exports:
+
+````typescript
+/**
+ * Summary line — one sentence, no period
+ *
+ * @remarks
+ * Extended description. Multiple paragraphs allowed.
+ *
+ * @typeParam T - Description of the generic parameter.
+ *
+ * @usage
+ * When and why to use this export.
+ *
+ * @example
+ * ```typescript
+ * // usage example
+ * ```
+ *
+ * @category Models
+ * @category Foundational
+ * @displayName Base Model
+ * @order 1
+ * @since 1.0.0
+ * @related OtherExport
+ *
+ * @public
+ */
+````
+
+Member-level comment structure (properties, methods):
+
+```typescript
+/**
+ * Summary line — one sentence, no period
+ *
+ * @remarks
+ * Extended description if needed.
+ *
+ * @order 1
+ *
+ * @public
+ */
+```
+
+### Tag Ordering
+
+Follow this order within a TSDoc comment:
+
+Top-level exports: summary line → `@remarks` → `@typeParam` / `@param` / `@returns` → `@usage` → `@example` → `@category` (repeatable) → `@displayName` → `@order` → `@since` → `@related` (repeatable) → `@public` / `@internal`
+
+Members (properties, methods): summary line → `@remarks` → `@param` / `@returns` (methods only) → `@order` → `@public` / `@internal`
+
 ## Commit Convention
 
 Follow **Conventional Commits** strictly:

--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ Abstract base class for feature services. Provides typed HTTP methods with built
 
 ## License
 
-[Apache-2.0 ↗](https://www.apache.org/licenses/LICENSE-2.0) — Copyright 2025 TeqBench
+[Apache-2.0](LICENSE) — Copyright 2025 TeqBench

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Abstract base class for feature services. Provides typed HTTP methods with built
 | [TypeScript ↗](https://www.typescriptlang.org/) | ~5.9.0                        |
 | [Node.js ↗](https://nodejs.org/)                | >=24.0.0                      |
 
+## Feedback
+
+Found a bug or have an idea for a new feature? Open an issue using one of the provided templates:
+
+- [Bug Report](https://github.com/teqbench/tbx-ngx-http/issues/new?template=bug_report.md)
+- [Feature Request](https://github.com/teqbench/tbx-ngx-http/issues/new?template=feature_request.md)
+
 ## License
 
 [Apache-2.0](LICENSE) — Copyright 2025 TeqBench

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ Abstract base class for feature services. Provides typed HTTP methods with built
 
 ## Compatibility
 
-| Dependency | Version                       |
-| ---------- | ----------------------------- |
-| Angular    | ^19.0.0 \| ^20.0.0 \| ^21.0.0 |
-| RxJS       | ^7.0.0                        |
-| TypeScript | ~5.9.0                        |
-| Node.js    | >=24.0.0                      |
+| Dependency                                      | Version                       |
+| ----------------------------------------------- | ----------------------------- |
+| [Angular ↗](https://angular.dev/)               | ^19.0.0 \| ^20.0.0 \| ^21.0.0 |
+| [RxJS ↗](https://rxjs.dev/)                     | ^7.0.0                        |
+| [TypeScript ↗](https://www.typescriptlang.org/) | ~5.9.0                        |
+| [Node.js ↗](https://nodejs.org/)                | >=24.0.0                      |
 
 ## License
 
-[Apache-2.0](LICENSE) — Copyright 2025 TeqBench
+[Apache-2.0 ↗](https://www.apache.org/licenses/LICENSE-2.0) — Copyright 2025 TeqBench

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ npm install @teqbench/tbx-ngx-http
 
 ```typescript
 import { Injectable } from '@angular/core';
-import { TbxNgxBaseHttpService } from '@teqbench/tbx-ngx-http';
+import { TbxNgxHttpService } from '@teqbench/tbx-ngx-http';
 import { environment } from '../environments/environment';
 
 @Injectable({ providedIn: 'root' })
-export class UserService extends TbxNgxBaseHttpService {
+export class UserService extends TbxNgxHttpService {
     protected override readonly baseUrl = environment.apiUrl;
 
     getUser(id: string) {
@@ -41,7 +41,7 @@ export class UserService extends TbxNgxBaseHttpService {
 
 ## API Reference
 
-### `TbxNgxBaseHttpService` (abstract class)
+### `TbxNgxHttpService` (abstract class)
 
 Abstract base class for feature services. Provides typed HTTP methods with built-in resilience.
 

--- a/docs/reference/workflows/ci.md
+++ b/docs/reference/workflows/ci.md
@@ -119,9 +119,9 @@ Fails the build on high or critical severity vulnerabilities. Runs immediately a
 npm run format:check
 ```
 
-Runs `prettier --check .` against all tracked files. Also enforced locally via the Husky `pre-commit` hook — the CI step is the safety net.
+Runs `[Prettier ↗](https://prettier.io/) --check .` against all tracked files. Also enforced locally via the [Husky ↗](https://typicode.github.io/husky/) `pre-commit` hook — the CI step is the safety net.
 
-#### 8. TypeScript Check
+#### 8. [TypeScript ↗](https://www.typescriptlang.org/) Check
 
 ```bash
 npm run typecheck
@@ -135,7 +135,7 @@ Full type-check (`tsc --noEmit`) without emitting output.
 npm run lint
 ```
 
-Runs ESLint with the flat config (`eslint.config.js`).
+Runs [ESLint ↗](https://eslint.org/) with the flat config (`eslint.config.js`).
 
 #### 10. Run Tests with Coverage
 
@@ -143,7 +143,7 @@ Runs ESLint with the flat config (`eslint.config.js`).
 npm run test:coverage
 ```
 
-Runs `vitest run --coverage`, enforcing the coverage thresholds configured in `vitest.config.ts`:
+Runs `[Vitest ↗](https://vitest.dev/) run --coverage`, enforcing the coverage thresholds configured in `vitest.config.ts`:
 
 - 80% lines, functions, and statements
 - 75% branches
@@ -159,7 +159,7 @@ Extracts badge data from test output for the gist push steps:
 
 #### 12. Check README Version Drift
 
-Compares the TypeScript and Node.js versions in `README.md`'s compatibility table against `package.json`. Fails the build if they don't match, preventing documentation drift after dependency updates.
+Compares the [TypeScript ↗](https://www.typescriptlang.org/) and [Node.js ↗](https://nodejs.org/) versions in `README.md`'s compatibility table against `package.json`. Fails the build if they don't match, preventing documentation drift after dependency updates.
 
 #### 13. Build
 

--- a/docs/reference/workflows/ci.md
+++ b/docs/reference/workflows/ci.md
@@ -7,7 +7,7 @@
 
 ## Purpose
 
-The CI workflow is the quality gate for the repository. It runs formatting checks, type checking, linting, tests with coverage enforcement, dependency auditing, and README version drift detection on every push and pull request to `main` and `dev`. After a successful push (not PR), it pushes badge data to a shared GitHub Gist and updates the README with branch-specific Shields.io badge URLs.
+The CI workflow is the quality gate for the repository. It runs formatting checks, type checking, linting, tests with coverage enforcement, dependency auditing, and README version drift detection on every push and pull request to `main` and `dev`. After a successful push (not PR), it pushes badge data to a shared [GitHub Gist ↗](https://gist.github.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4) and updates the README with branch-specific [Shields.io ↗](https://shields.io) badge URLs.
 
 ---
 
@@ -77,7 +77,7 @@ PRs to `main` must come from `release/*`, `hotfix/*`, or `release-please--*` bra
 
 Uses `actions/create-github-app-token@v3` to create a short-lived token from the `teqbench-automation` GitHub App.
 
-This step is conditioned on `github.actor != 'dependabot[bot]'` and is **skipped entirely** on Dependabot PRs. The app secrets are intentionally unavailable to Dependabot — GitHub isolates Dependabot from repository secrets as a security boundary.
+This step is conditioned on `github.actor != 'dependabot[bot]'` and is **skipped entirely** on [Dependabot ↗](https://docs.github.com/en/code-security/dependabot) PRs. The app secrets are intentionally unavailable to Dependabot — GitHub isolates Dependabot from repository secrets as a security boundary.
 
 #### 3. Checkout Code
 
@@ -89,7 +89,7 @@ with:
     fetch-depth: 0
 ```
 
-Uses the app token when available. Falls back to `GITHUB_TOKEN` for Dependabot PRs. Submodules (Claude Code skills) are checked out for non-Dependabot runs. `fetch-depth: 0` fetches full history.
+Uses the app token when available. Falls back to `GITHUB_TOKEN` for [Dependabot ↗](https://docs.github.com/en/code-security/dependabot) PRs. Submodules (Claude Code skills) are checked out for non-Dependabot runs. `fetch-depth: 0` fetches full history.
 
 #### 4. Setup Node
 
@@ -101,9 +101,9 @@ Reads the Node version from `.nvmrc` with npm cache enabled.
 npm ci
 ```
 
-Clean install from `package-lock.json` for deterministic builds. `GITHUB_TOKEN` is used with `packages: read` permission (inherited from the job's `contents: read` scope) to authenticate with GitHub Packages.
+Clean install from `package-lock.json` for deterministic builds. `GITHUB_TOKEN` is used with `packages: read` permission (inherited from the job's `contents: read` scope) to authenticate with [GitHub Packages ↗](https://github.com/orgs/teqbench/packages).
 
-> **Cross-repo `@teqbench` dependencies:** For packages that depend on other `@teqbench` packages, each dependency package must grant the consuming repository read access in its package settings (**GitHub Packages → Manage access**). This applies to the entire transitive dependency tree, not just direct dependencies. Without this, `npm ci` will fail with `403 Forbidden`.
+> **Cross-repo `@teqbench` dependencies:** For packages that depend on other `@teqbench` packages, each dependency package must grant the consuming repository read access in its package settings (**[GitHub Packages ↗](https://github.com/orgs/teqbench/packages) → Manage access**). This applies to the entire transitive dependency tree, not just direct dependencies. Without this, `npm ci` will fail with `403 Forbidden`.
 
 #### 6. Audit Dependencies
 
@@ -119,9 +119,9 @@ Fails the build on high or critical severity vulnerabilities. Runs immediately a
 npm run format:check
 ```
 
-Runs `[Prettier ↗](https://prettier.io/) --check .` against all tracked files. Also enforced locally via the [Husky ↗](https://typicode.github.io/husky/) `pre-commit` hook — the CI step is the safety net.
+Runs `prettier --check .` against all tracked files. Also enforced locally via the [Husky ↗](https://typicode.github.io/husky/) `pre-commit` hook — the CI step is the safety net.
 
-#### 8. [TypeScript ↗](https://www.typescriptlang.org/) Check
+#### 8. TypeScript Check
 
 ```bash
 npm run typecheck
@@ -143,7 +143,7 @@ Runs [ESLint ↗](https://eslint.org/) with the flat config (`eslint.config.js`)
 npm run test:coverage
 ```
 
-Runs `[Vitest ↗](https://vitest.dev/) run --coverage`, enforcing the coverage thresholds configured in `vitest.config.ts`:
+Runs `vitest run --coverage`, enforcing the coverage thresholds configured in `vitest.config.ts`:
 
 - 80% lines, functions, and statements
 - 75% branches
@@ -171,7 +171,7 @@ Compiles TypeScript to `dist/` using `tsconfig.build.json`.
 
 #### 14–18. Push Badge Data to Gist
 
-Five badges are pushed as JSON to a shared public GitHub Gist using `schneegans/dynamic-badges-action@v1.7.0`. [Shields.io](https://shields.io) reads the JSON and renders the badges dynamically. Only runs on **push events** (not PRs).
+Five badges are pushed as JSON to a shared public GitHub Gist using `schneegans/dynamic-badges-action@v1.7.0`. [Shields.io ↗](https://shields.io) reads the JSON and renders the badges dynamically. Only runs on **push events** (not PRs).
 
 | Badge        | Style         | Source                                            | Gist Filename                       |
 | ------------ | ------------- | ------------------------------------------------- | ----------------------------------- |
@@ -196,13 +196,13 @@ All badge steps run with `if: always()` so badges update even on failure. The `s
 
 ## Badge Rendering
 
-Badges are rendered by [Shields.io endpoint badges](https://shields.io/badges/endpoint-badge). The URL format is:
+Badges are rendered by [Shields.io ↗](https://shields.io) endpoint badges. The URL format is:
 
 ```
 https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/{GIST_OWNER}/{GIST_ID}/raw/{REPO_NAME}-{BRANCH}-{badge}.json
 ```
 
-The gist stores JSON files matching the [Shields.io endpoint schema](https://shields.io/badges/endpoint-badge):
+The gist stores JSON files matching the [Shields.io ↗](https://shields.io) endpoint schema:
 
 ```json
 {
@@ -214,4 +214,4 @@ The gist stores JSON files matching the [Shields.io endpoint schema](https://shi
 }
 ```
 
-Shields.io caches responses for ~5 minutes. After a CI run, badges may take a few minutes to reflect new data.
+[Shields.io ↗](https://shields.io) caches responses for ~5 minutes. After a CI run, badges may take a few minutes to reflect new data.

--- a/docs/reference/workflows/claude.md
+++ b/docs/reference/workflows/claude.md
@@ -50,11 +50,11 @@ jobs:
 
 ## Secrets Used
 
-| Secret              | Purpose                                  |
-| ------------------- | ---------------------------------------- |
-| `APP_ID`            | GitHub App ID for generating a bot token |
-| `APP_PRIVATE_KEY`   | GitHub App private key                   |
-| `ANTHROPIC_API_KEY` | Authenticates with the Anthropic API     |
+| Secret              | Purpose                                                                                     |
+| ------------------- | ------------------------------------------------------------------------------------------- |
+| `APP_ID`            | GitHub App ID for generating a bot token                                                    |
+| `APP_PRIVATE_KEY`   | GitHub App private key                                                                      |
+| `ANTHROPIC_API_KEY` | Authenticates with the [Anthropic API ↗](https://docs.anthropic.com/en/api/getting-started) |
 
 The app token is used for checkout with submodules (Claude Code skills) and for full repository access.
 
@@ -154,11 +154,11 @@ Claude's capabilities are explicitly restricted via `--allowedTools` to prevent 
 
 ### npm Commands (Via Bash Allowlist)
 
-| Allowed   | Purpose                                 |
-| --------- | --------------------------------------- |
-| `npm run` | Run project scripts (test, lint, build) |
-| `npm ci`  | Install dependencies                    |
-| `npx`     | Run Node.js binaries                    |
+| Allowed   | Purpose                                       |
+| --------- | --------------------------------------------- |
+| `npm run` | Run project scripts (test, lint, build)       |
+| `npm ci`  | Install dependencies                          |
+| `npx`     | Run [Node.js ↗](https://nodejs.org/) binaries |
 
 ---
 

--- a/docs/reference/workflows/dep-compat-check.md
+++ b/docs/reference/workflows/dep-compat-check.md
@@ -7,7 +7,7 @@
 
 ## Purpose
 
-Tracks pinned dependencies that are waiting for a new version — for example, waiting for a package to release a compatible major version before it can be adopted. The workflow checks the npm registry daily, evaluates resolution conditions, and posts status updates to a tracking issue.
+Tracks pinned dependencies that are waiting for a new version — for example, waiting for a package to release a compatible major version before it can be adopted. The workflow checks the [npm ↗](https://www.npmjs.com/) registry daily, evaluates resolution conditions, and posts status updates to a tracking issue.
 
 ---
 
@@ -78,7 +78,7 @@ also-track: @angular/cli, @angular/compiler
 ### Evaluation Flow
 
 1. Finds open issues with `Part of #<EPIC>` and `<!-- dep-compat ... -->` metadata.
-2. For each, queries the npm registry for the latest version.
+2. For each, queries the [npm ↗](https://www.npmjs.com/) registry for the latest version.
 3. Evaluates the resolution condition against the current version.
 4. Compares version fingerprints with the last bot comment to detect changes.
 5. Posts a summary comment if: versions changed, it's Monday, or the workflow was triggered manually.

--- a/docs/reference/workflows/dependabot.md
+++ b/docs/reference/workflows/dependabot.md
@@ -61,7 +61,7 @@ Updates action versions used in all workflow files (e.g., `actions/checkout@v4` 
 
 Some dependencies are intentionally pinned without caret ranges (see `devDependenciesPinned` in `package.json`):
 
-- **`typescript-eslint`** — pinned without `^` because patch releases have introduced breaking rule changes
+- **`[typescript-eslint ↗](https://typescript-eslint.io/)`** — pinned without `^` because patch releases have introduced breaking rule changes
 - **`@types/node`** — pinned to `~24.0.0` to match the Node 24 runtime
 
 Dependabot will still open PRs for these packages. Review them carefully and test before merging — the pinning is intentional and documented.

--- a/docs/reference/workflows/dependabot.md
+++ b/docs/reference/workflows/dependabot.md
@@ -6,7 +6,7 @@
 
 ## Purpose
 
-Automatically opens pull requests to update dependencies on a weekly schedule. PRs target the `dev` branch (not `main`) and use conventional commit message prefixes so they integrate cleanly with the release-please workflow.
+Automatically opens pull requests to update dependencies on a weekly schedule. PRs target the `dev` branch (not `main`) and use conventional commit message prefixes so they integrate cleanly with the [Release Please ↗](https://github.com/googleapis/release-please) workflow.
 
 ---
 
@@ -18,7 +18,7 @@ Runs every **Monday**.
 
 ## Target Branch
 
-All Dependabot PRs target **`dev`**, not `main`. This ensures dependency updates go through the standard PR review and CI pipeline before reaching production.
+All [Dependabot ↗](https://docs.github.com/en/code-security/dependabot) PRs target **`dev`**, not `main`. This ensures dependency updates go through the standard PR review and CI pipeline before reaching production.
 
 ---
 
@@ -61,18 +61,18 @@ Updates action versions used in all workflow files (e.g., `actions/checkout@v4` 
 
 Some dependencies are intentionally pinned without caret ranges (see `devDependenciesPinned` in `package.json`):
 
-- **`[typescript-eslint ↗](https://typescript-eslint.io/)`** — pinned without `^` because patch releases have introduced breaking rule changes
+- **[typescript-eslint ↗](https://typescript-eslint.io/)** — pinned without `^` because patch releases have introduced breaking rule changes
 - **`@types/node`** — pinned to `~24.0.0` to match the Node 24 runtime
 
-Dependabot will still open PRs for these packages. Review them carefully and test before merging — the pinning is intentional and documented.
+[Dependabot ↗](https://docs.github.com/en/code-security/dependabot) will still open PRs for these packages. Review them carefully and test before merging — the pinning is intentional and documented.
 
 ---
 
 ## CI Integration
 
-Dependabot PRs trigger the CI workflow like any other PR. However, the CI workflow handles Dependabot specially:
+[Dependabot ↗](https://docs.github.com/en/code-security/dependabot) PRs trigger the CI workflow like any other PR. However, the CI workflow handles [Dependabot ↗](https://docs.github.com/en/code-security/dependabot) specially:
 
-- **App token generation is skipped** — Dependabot cannot access repository secrets
-- **Submodule checkout is skipped** — Dependabot cannot access private submodules
+- **App token generation is skipped** — [Dependabot ↗](https://docs.github.com/en/code-security/dependabot) cannot access repository secrets
+- **Submodule checkout is skipped** — [Dependabot ↗](https://docs.github.com/en/code-security/dependabot) cannot access private submodules
 - **Falls back to `GITHUB_TOKEN`** — sufficient for read-only validation (audit, lint, typecheck, test)
 - **Badge commits are not generated** — badges only commit on push events, not PRs

--- a/docs/reference/workflows/release.md
+++ b/docs/reference/workflows/release.md
@@ -7,7 +7,7 @@
 
 ## Purpose
 
-The Release workflow automates versioning, changelog generation, GitHub Release creation, and npm publishing using Google's [release-please](https://github.com/googleapis/release-please). It eliminates the need to manually edit version numbers, write changelogs, or create release tags. When a release is created, the package is automatically published to GitHub Packages.
+The Release workflow automates versioning, changelog generation, GitHub Release creation, and npm publishing using Google's [Release Please ↗](https://github.com/googleapis/release-please). It eliminates the need to manually edit version numbers, write changelogs, or create release tags. When a release is created, the package is automatically published to GitHub Packages.
 
 ---
 
@@ -101,12 +101,12 @@ permissions:
 ### Steps
 
 1. **Checkout code** — Standard checkout (no full history needed).
-2. **Setup Node** — Configures Node from `.nvmrc` with `registry-url: "https://npm.pkg.github.com"` for GitHub Packages authentication.
+2. **Setup Node** — Configures Node from `.nvmrc` with `registry-url: "https://npm.pkg.github.com"` for [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) authentication.
 3. **Install dependencies** — `npm ci` for deterministic builds. `GITHUB_TOKEN` with `packages: write` handles publishing to the current repo's package, and `packages: read` (inherited) handles installing dependencies.
 4. **Build** — `npm run build` compiles TypeScript to `dist/`.
 5. **Publish** — `npm publish` with `NODE_AUTH_TOKEN` set to `GITHUB_TOKEN`. The `"files": ["dist"]` field in `package.json` ensures only compiled output is included.
 
-> **Cross-repo `@teqbench` dependencies:** For packages that depend on other `@teqbench` packages, each dependency package must grant the consuming repository read access in its package settings (**GitHub Packages → Manage access**). This applies to the entire transitive dependency tree, not just direct dependencies — same as CI.
+> **Cross-repo `@teqbench` dependencies:** For packages that depend on other `@teqbench` packages, each dependency package must grant the consuming repository read access in its package settings (**[GitHub Packages ↗](https://github.com/orgs/teqbench/packages) → Manage access**). This applies to the entire transitive dependency tree, not just direct dependencies — same as CI.
 
 ---
 
@@ -114,7 +114,7 @@ permissions:
 
 ### Phase 1: Create/Update Release PR
 
-After a push to `main` that includes conventional commits (`feat:`, `fix:`), release-please:
+After a push to `main` that includes [Conventional Commits ↗](https://conventionalcommits.org/) (`feat:`, `fix:`), [Release Please ↗](https://github.com/googleapis/release-please):
 
 1. Reads all conventional commits since the last release tag.
 2. Determines the version bump:
@@ -135,7 +135,7 @@ When the Release PR is merged:
 
 1. Creates a GitHub Release with auto-generated release notes.
 2. Creates a git tag (e.g., `v0.1.1`).
-3. The `publish` job runs — builds and publishes the package to GitHub Packages.
+3. The `publish` job runs — builds and publishes the package to [GitHub Packages ↗](https://github.com/orgs/teqbench/packages).
 4. The push to `main` from the merge triggers CI (to update badges) and Sync (to merge main into dev).
 
 ---
@@ -165,7 +165,7 @@ When the Release PR is merged:
 
 Key settings:
 
-- **`release-type: node`** — uses Node.js release strategy (reads `package.json`).
+- **`release-type: node`** — uses [Node.js ↗](https://nodejs.org/) release strategy (reads `package.json`).
 - **`extra-files`** — also bumps version in `package-lock.json` at two JSON paths.
 - **`include-component-in-tag: false`** — produces clean tags like `v0.1.1` instead of prefixed tags.
 - **`changelog-path`** — writes changelog to the repo root.

--- a/docs/reference/workflows/sync.md
+++ b/docs/reference/workflows/sync.md
@@ -7,7 +7,7 @@
 
 ## Purpose
 
-After release-please merges a Release PR to `main`, the `dev` branch falls behind — it's missing the version bump in `package.json`, the updated `CHANGELOG.md`, and the new `.release-please-manifest.json`. This workflow automatically merges `main` back into `dev` to keep the branches in sync.
+After [Release Please ↗](https://github.com/googleapis/release-please) merges a Release PR to `main`, the `dev` branch falls behind — it's missing the version bump in `package.json`, the updated `CHANGELOG.md`, and the new `.release-please-manifest.json`. This workflow automatically merges `main` back into `dev` to keep the branches in sync.
 
 ---
 
@@ -113,7 +113,7 @@ git push origin dev
 
 ## Interaction with Other Workflows
 
-| What Happens                 | Result                                                                                                                                          |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| Sync pushes to `dev`         | CI on `dev` is **skipped** — the `[skip ci]` tag in the merge commit message suppresses the `push` trigger per the GitHub Actions specification |
-| Sync races with another push | Handled by `git pull --rebase` before pushing                                                                                                   |
+| What Happens                 | Result                                                                                                                                                                                  |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Sync pushes to `dev`         | CI on `dev` is **skipped** — the `[skip ci]` tag in the merge commit message suppresses the `push` trigger per the [GitHub Actions ↗](https://docs.github.com/en/actions) specification |
+| Sync races with another push | Handled by `git pull --rebase` before pushing                                                                                                                                           |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 import tseslint from 'typescript-eslint';
 import angular from 'angular-eslint';
+import tsdoc from 'eslint-plugin-tsdoc';
 
 export default tseslint.config(
     {
@@ -8,6 +9,7 @@ export default tseslint.config(
     ...tseslint.configs.recommended,
     ...angular.configs.tsRecommended,
     {
+        plugins: { tsdoc },
         languageOptions: {
             parserOptions: {
                 projectService: {
@@ -25,6 +27,7 @@ export default tseslint.config(
                 'error',
                 { type: 'element', prefix: 'tbx', style: 'kebab-case' },
             ],
+            'tsdoc/syntax': 'warn',
         },
     }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@vitest/coverage-v8": "^4.1.1",
         "angular-eslint": "^21.3.1",
         "eslint": "^10.1.0",
+        "eslint-plugin-tsdoc": "^0.5.2",
         "husky": "^9.1.7",
         "jsdom": "^26.1.0",
         "lint-staged": "^16.3.3",
@@ -2398,6 +2399,26 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/tsdoc-config": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
+      "integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "ajv": "~8.18.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.2"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.26.0",
@@ -6022,6 +6043,172 @@
         }
       }
     },
+    "node_modules/eslint-plugin-tsdoc": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.5.2.tgz",
+      "integrity": "sha512-BlvqjWZdBJDIPO/YU3zcPCF23CvjYT3gyu63yo6b609NNV3D1b6zceAREy2xnweuBoDpZcLNuPyAUq9cvx6bbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@microsoft/tsdoc-config": "0.18.1",
+        "@typescript-eslint/utils": "~8.56.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/types": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
@@ -6584,7 +6771,6 @@
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6753,7 +6939,6 @@
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -7054,6 +7239,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -7219,6 +7420,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jose": {
       "version": "6.2.2",
@@ -8810,6 +9018,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-scurry": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
@@ -9172,6 +9387,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/restore-cursor": {
@@ -9932,6 +10168,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Base HTTP communication services and resilience constants for Angular. Provides automatic retries with exponential backoff, timeout handling, and consistent URL resolution for feature services.",
   "type": "module",
   "license": "Apache-2.0",
+  "keywords": [
+    "angular"
+  ],
   "engines": {
     "node": ">=24.0.0"
   },
@@ -50,6 +53,7 @@
     "@vitest/coverage-v8": "^4.1.1",
     "angular-eslint": "^21.3.1",
     "eslint": "^10.1.0",
+    "eslint-plugin-tsdoc": "^0.5.2",
     "husky": "^9.1.7",
     "jsdom": "^26.1.0",
     "lint-staged": "^16.3.3",

--- a/src/constants/http.constants.ts
+++ b/src/constants/http.constants.ts
@@ -4,12 +4,12 @@ import { StatusCodes } from 'http-status-codes';
  * Default request timeout in milliseconds
  *
  * @remarks
- * Applied to every HTTP request made through {@link TbxNgxBaseHttpService}.
+ * Applied to every HTTP request made through {@link TbxNgxHttpService}.
  * Subclasses override by redeclaring the `DEFAULT_TIMEOUT` class property.
  *
  * @usage
  * Import directly when building a custom retry or timeout strategy outside of
- * TbxNgxBaseHttpService.
+ * TbxNgxHttpService.
  *
  * @example
  * ```typescript
@@ -20,7 +20,7 @@ import { StatusCodes } from 'http-status-codes';
  * @displayName Default Timeout
  * @order 1
  * @since 1.0.0
- * @related TbxNgxBaseHttpService
+ * @related TbxNgxHttpService
  *
  * @public
  */
@@ -31,12 +31,12 @@ export const TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS = 10_000;
  *
  * @remarks
  * Controls how many times a failed GET request is retried before the error
- * propagates to the caller. Subclasses of {@link TbxNgxBaseHttpService} override
+ * propagates to the caller. Subclasses of {@link TbxNgxHttpService} override
  * by redeclaring the `RETRY_COUNT` class property.
  *
  * @usage
  * Import directly when building a custom retry strategy outside of
- * TbxNgxBaseHttpService.
+ * TbxNgxHttpService.
  *
  * @example
  * ```typescript
@@ -47,7 +47,7 @@ export const TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS = 10_000;
  * @displayName Retry Count
  * @order 2
  * @since 1.0.0
- * @related TbxNgxBaseHttpService
+ * @related TbxNgxHttpService
  *
  * @public
  */
@@ -58,12 +58,12 @@ export const TBX_NGX_HTTP_RETRY_COUNT = 2;
  *
  * @remarks
  * The actual delay follows the formula `RETRY_DELAY * 2^(attempt - 1)`.
- * Subclasses of {@link TbxNgxBaseHttpService} override by redeclaring the
+ * Subclasses of {@link TbxNgxHttpService} override by redeclaring the
  * `RETRY_DELAY` class property.
  *
  * @usage
  * Import directly when building a custom backoff strategy outside of
- * TbxNgxBaseHttpService.
+ * TbxNgxHttpService.
  *
  * @example
  * ```typescript
@@ -74,7 +74,7 @@ export const TBX_NGX_HTTP_RETRY_COUNT = 2;
  * @displayName Retry Delay
  * @order 3
  * @since 1.0.0
- * @related TbxNgxBaseHttpService
+ * @related TbxNgxHttpService
  *
  * @public
  */
@@ -106,7 +106,7 @@ export const TBX_NGX_HTTP_RETRY_DELAY_MS = 1_000;
  *
  * @usage
  * Import directly when implementing a custom retry predicate that needs to
- * reference the same set of retryable statuses used by TbxNgxBaseHttpService.
+ * reference the same set of retryable statuses used by TbxNgxHttpService.
  *
  * @example
  * ```typescript
@@ -121,7 +121,7 @@ export const TBX_NGX_HTTP_RETRY_DELAY_MS = 1_000;
  * @displayName Retryable Statuses
  * @order 4
  * @since 1.0.0
- * @related TbxNgxBaseHttpService
+ * @related TbxNgxHttpService
  *
  * @public
  */

--- a/src/constants/http.constants.ts
+++ b/src/constants/http.constants.ts
@@ -1,44 +1,129 @@
 import { StatusCodes } from 'http-status-codes';
 
 /**
- * HTTP resilience defaults for TbxNgxBaseHttpService.
+ * Default request timeout in milliseconds
  *
- * These are the library-shipped defaults. Subclasses override behavior
- * by redeclaring the corresponding class property on TbxNgxBaseHttpService —
- * they do not need to import this file directly.
+ * @remarks
+ * Applied to every HTTP request made through {@link TbxNgxBaseHttpService}.
+ * Subclasses override by redeclaring the `DEFAULT_TIMEOUT` class property.
  *
- * Consuming apps that need to reference the defaults (e.g., in a custom
- * retry strategy) can import from '@teqbench/tbx-ngx-http':
+ * @usage
+ * Import directly when building a custom retry or timeout strategy outside of
+ * TbxNgxBaseHttpService.
  *
  * @example
  * ```typescript
- * import { TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS, TBX_NGX_HTTP_RETRYABLE_STATUSES } from '@teqbench/tbx-ngx-http';
+ * import { TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS } from '@teqbench/tbx-ngx-http';
  * ```
+ *
+ * @category Constants
+ * @displayName Default Timeout
+ * @order 1
+ * @since 1.0.0
+ * @related TbxNgxBaseHttpService
+ *
+ * @public
  */
-
-/** Default request timeout in milliseconds. */
 export const TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS = 10_000;
 
-/** Number of retry attempts for idempotent requests (GET only). */
+/**
+ * Number of retry attempts for idempotent requests (GET only)
+ *
+ * @remarks
+ * Controls how many times a failed GET request is retried before the error
+ * propagates to the caller. Subclasses of {@link TbxNgxBaseHttpService} override
+ * by redeclaring the `RETRY_COUNT` class property.
+ *
+ * @usage
+ * Import directly when building a custom retry strategy outside of
+ * TbxNgxBaseHttpService.
+ *
+ * @example
+ * ```typescript
+ * import { TBX_NGX_HTTP_RETRY_COUNT } from '@teqbench/tbx-ngx-http';
+ * ```
+ *
+ * @category Constants
+ * @displayName Retry Count
+ * @order 2
+ * @since 1.0.0
+ * @related TbxNgxBaseHttpService
+ *
+ * @public
+ */
 export const TBX_NGX_HTTP_RETRY_COUNT = 2;
 
-/** Base delay in milliseconds for exponential backoff between retries. */
+/**
+ * Base delay in milliseconds for exponential backoff between retries
+ *
+ * @remarks
+ * The actual delay follows the formula `RETRY_DELAY * 2^(attempt - 1)`.
+ * Subclasses of {@link TbxNgxBaseHttpService} override by redeclaring the
+ * `RETRY_DELAY` class property.
+ *
+ * @usage
+ * Import directly when building a custom backoff strategy outside of
+ * TbxNgxBaseHttpService.
+ *
+ * @example
+ * ```typescript
+ * import { TBX_NGX_HTTP_RETRY_DELAY_MS } from '@teqbench/tbx-ngx-http';
+ * ```
+ *
+ * @category Constants
+ * @displayName Retry Delay
+ * @order 3
+ * @since 1.0.0
+ * @related TbxNgxBaseHttpService
+ *
+ * @public
+ */
 export const TBX_NGX_HTTP_RETRY_DELAY_MS = 1_000;
 
 /**
- * HTTP status codes eligible for automatic retry.
+ * HTTP status codes eligible for automatic retry
  *
+ * @remarks
  * Only transient server errors and network failures are retried.
  * 4xx client errors (except 408 and 429) indicate a malformed request
  * that will not succeed on retry.
  *
- * - `0`   — Network error (no response received; browser reports status 0)
- * - `408` — Request Timeout (server did not receive a complete request in time)
+ * Included status codes:
+ *
+ * - `0` — Network error (no response received; browser reports status 0)
+ *
+ * - `408` — Request Timeout
+ *
  * - `429` — Too Many Requests (rate-limited; retry after backoff)
- * - `500` — Internal Server Error (generic server failure)
- * - `502` — Bad Gateway (upstream server returned an invalid response)
- * - `503` — Service Unavailable (server temporarily overloaded or in maintenance)
- * - `504` — Gateway Timeout (upstream server did not respond in time)
+ *
+ * - `500` — Internal Server Error
+ *
+ * - `502` — Bad Gateway
+ *
+ * - `503` — Service Unavailable
+ *
+ * - `504` — Gateway Timeout
+ *
+ * @usage
+ * Import directly when implementing a custom retry predicate that needs to
+ * reference the same set of retryable statuses used by TbxNgxBaseHttpService.
+ *
+ * @example
+ * ```typescript
+ * import { TBX_NGX_HTTP_RETRYABLE_STATUSES } from '@teqbench/tbx-ngx-http';
+ *
+ * if (TBX_NGX_HTTP_RETRYABLE_STATUSES.has(response.status)) {
+ *     // retry logic
+ * }
+ * ```
+ *
+ * @category Constants
+ * @displayName Retryable Statuses
+ * @order 4
+ * @since 1.0.0
+ * @related TbxNgxBaseHttpService
+ *
+ * @public
  */
 export const TBX_NGX_HTTP_RETRYABLE_STATUSES = new Set([
     0, // Network error — no HTTP standard; browser-specific status when no response is received

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  * @remarks
  * This barrel file provides a centralized entry point for base HTTP communication
  * services and resilience constants. Feature services extend
- * {@link TbxNgxBaseHttpService} to get automatic retries with exponential backoff
+ * {@link TbxNgxHttpService} to get automatic retries with exponential backoff
  * on GET requests, timeout handling, consistent URL resolution, and default headers.
  *
  * Resilience constants ({@link TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS},
@@ -15,8 +15,6 @@
  * @packageDocumentation
  */
 export * from './constants/http.constants';
-export {
-    TbxNgxBaseHttpService,
-    type TbxNgxHttpRequestOptions,
-    type TbxNgxHttpBodyRequestOptions,
-} from './services/base-http.service';
+export { TbxNgxHttpService } from './services/base-http.service';
+export { type TbxNgxHttpRequestOptions } from './models/http-request-options.model';
+export { type TbxNgxHttpBodyRequestOptions } from './models/http-body-request-options.model';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,18 @@
 /**
- * Public API Surface for the HTTP Core Domain.
+ * Public API surface for `@teqbench/tbx-ngx-http`
  *
- * This barrel file provides a centralized entry point for base communication
- * services and resilience constants. It allows feature services to extend
- * standard API behaviors—such as automatic retries, timeout handling, and
- * consistent URL resolution—without coupling them to specific implementation
- * details.
+ * @remarks
+ * This barrel file provides a centralized entry point for base HTTP communication
+ * services and resilience constants. Feature services extend
+ * {@link TbxNgxBaseHttpService} to get automatic retries with exponential backoff
+ * on GET requests, timeout handling, consistent URL resolution, and default headers.
+ *
+ * Resilience constants ({@link TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS},
+ * {@link TBX_NGX_HTTP_RETRY_COUNT}, {@link TBX_NGX_HTTP_RETRY_DELAY_MS},
+ * {@link TBX_NGX_HTTP_RETRYABLE_STATUSES}) are exported for direct use by
+ * consuming applications that need to reference the library defaults.
+ *
+ * @packageDocumentation
  */
 export * from './constants/http.constants';
 export {

--- a/src/models/http-body-request-options.model.ts
+++ b/src/models/http-body-request-options.model.ts
@@ -1,0 +1,29 @@
+import { HttpHeaders } from '@angular/common/http';
+
+/**
+ * Options accepted by body HTTP methods (POST, PUT, PATCH)
+ *
+ * @remarks
+ * Passed as the optional third argument to
+ * {@link TbxNgxHttpService.post | post},
+ * {@link TbxNgxHttpService.put | put}, and
+ * {@link TbxNgxHttpService.patch | patch}. When `headers` is provided,
+ * the service's default headers are replaced entirely (not merged).
+ *
+ * @category Interfaces
+ * @displayName HTTP Body Request Options
+ * @order 3
+ * @since 1.0.0
+ * @related TbxNgxHttpService
+ * @related TbxNgxHttpRequestOptions
+ *
+ * @public
+ */
+export interface TbxNgxHttpBodyRequestOptions {
+    /**
+     * HTTP headers for the request, replaces default headers when provided
+     *
+     * @public
+     */
+    headers?: HttpHeaders;
+}

--- a/src/models/http-request-options.model.ts
+++ b/src/models/http-request-options.model.ts
@@ -1,0 +1,34 @@
+import { HttpHeaders, HttpParams } from '@angular/common/http';
+
+/**
+ * Options accepted by non-body HTTP methods (GET, DELETE)
+ *
+ * @remarks
+ * Passed as the optional second argument to
+ * {@link TbxNgxHttpService.get | get} and
+ * {@link TbxNgxHttpService.delete | delete}. When `headers` is provided,
+ * the service's default headers are replaced entirely (not merged).
+ *
+ * @category Interfaces
+ * @displayName HTTP Request Options
+ * @order 2
+ * @since 1.0.0
+ * @related TbxNgxHttpService
+ * @related TbxNgxHttpBodyRequestOptions
+ *
+ * @public
+ */
+export interface TbxNgxHttpRequestOptions {
+    /**
+     * Query parameters appended to the request URL
+     *
+     * @public
+     */
+    params?: HttpParams;
+    /**
+     * HTTP headers for the request, replaces default headers when provided
+     *
+     * @public
+     */
+    headers?: HttpHeaders;
+}

--- a/src/services/base-http.service.spec.ts
+++ b/src/services/base-http.service.spec.ts
@@ -5,8 +5,10 @@ import { Injectable } from '@angular/core';
 import { Observable, of, catchError, firstValueFrom } from 'rxjs';
 import { StatusCodes, ReasonPhrases } from 'http-status-codes';
 
-import { TbxNgxBaseHttpService } from './base-http.service';
-import type { TbxNgxHttpRequestOptions, TbxNgxHttpBodyRequestOptions } from './base-http.service';
+import { TbxNgxHttpService } from './base-http.service';
+import type { TbxNgxHttpRequestOptions } from '../models/http-request-options.model';
+import type { TbxNgxHttpBodyRequestOptions } from '../models/http-body-request-options.model';
+
 import {
     TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS,
     TBX_NGX_HTTP_RETRY_COUNT,
@@ -16,12 +18,12 @@ import {
 const TEST_BASE_URL = 'https://api.test.com';
 
 /**
- * Concrete test harness that exposes TbxNgxBaseHttpService's protected methods.
+ * Concrete test harness that exposes TbxNgxHttpService's protected methods.
  * Each public method delegates directly to the corresponding base method
  * with the same signature, adding no logic of its own.
  */
 @Injectable()
-class TestDataService extends TbxNgxBaseHttpService {
+class TestDataService extends TbxNgxHttpService {
     protected override readonly baseUrl = TEST_BASE_URL;
 
     public testGet(options?: TbxNgxHttpRequestOptions) {
@@ -50,10 +52,10 @@ class TestDataService extends TbxNgxBaseHttpService {
  * for multi-cycle retry verification.
  *
  * This also validates the subclass override pattern documented in
- * TbxNgxBaseHttpService's JSDoc.
+ * TbxNgxHttpService's JSDoc.
  */
 @Injectable()
-class RetryTestService extends TbxNgxBaseHttpService {
+class RetryTestService extends TbxNgxHttpService {
     protected override readonly baseUrl = TEST_BASE_URL;
     protected override readonly RETRY_DELAY = 0;
 
@@ -67,7 +69,7 @@ class RetryTestService extends TbxNgxBaseHttpService {
  * Variant with a trailing-slash baseUrl to verify URL normalization.
  */
 @Injectable()
-class TrailingSlashService extends TbxNgxBaseHttpService {
+class TrailingSlashService extends TbxNgxHttpService {
     protected override readonly baseUrl = `${TEST_BASE_URL}/`;
 
     public testGet(path: string) {
@@ -77,7 +79,7 @@ class TrailingSlashService extends TbxNgxBaseHttpService {
 
 const TEST_URL = `${TEST_BASE_URL}/test`;
 
-describe('TbxNgxBaseHttpService', () => {
+describe('TbxNgxHttpService', () => {
     let service: TestDataService;
     let httpMock: HttpTestingController;
 

--- a/src/services/base-http.service.ts
+++ b/src/services/base-http.service.ts
@@ -9,25 +9,84 @@ import {
     TBX_NGX_HTTP_RETRYABLE_STATUSES,
 } from '../constants/http.constants';
 
-/** Options accepted by non-body methods (GET, DELETE). */
+/**
+ * Options accepted by non-body HTTP methods (GET, DELETE)
+ *
+ * @remarks
+ * Passed as the optional second argument to
+ * {@link TbxNgxBaseHttpService.get | get} and
+ * {@link TbxNgxBaseHttpService.delete | delete}. When `headers` is provided,
+ * the service's default headers are replaced entirely (not merged).
+ *
+ * @category Interfaces
+ * @displayName HTTP Request Options
+ * @order 2
+ * @since 1.0.0
+ * @related TbxNgxBaseHttpService
+ * @related TbxNgxHttpBodyRequestOptions
+ *
+ * @public
+ */
 export interface TbxNgxHttpRequestOptions {
+    /**
+     * Query parameters appended to the request URL
+     *
+     * @public
+     */
     params?: HttpParams;
-    headers?: HttpHeaders;
-}
-
-/** Options accepted by body methods (POST, PUT, PATCH). */
-export interface TbxNgxHttpBodyRequestOptions {
+    /**
+     * HTTP headers for the request, replaces default headers when provided
+     *
+     * @public
+     */
     headers?: HttpHeaders;
 }
 
 /**
- * Abstract base class for feature services that interact with the API.
+ * Options accepted by body HTTP methods (POST, PUT, PATCH)
  *
+ * @remarks
+ * Passed as the optional third argument to
+ * {@link TbxNgxBaseHttpService.post | post},
+ * {@link TbxNgxBaseHttpService.put | put}, and
+ * {@link TbxNgxBaseHttpService.patch | patch}. When `headers` is provided,
+ * the service's default headers are replaced entirely (not merged).
+ *
+ * @category Interfaces
+ * @displayName HTTP Body Request Options
+ * @order 3
+ * @since 1.0.0
+ * @related TbxNgxBaseHttpService
+ * @related TbxNgxHttpRequestOptions
+ *
+ * @public
+ */
+export interface TbxNgxHttpBodyRequestOptions {
+    /**
+     * HTTP headers for the request, replaces default headers when provided
+     *
+     * @public
+     */
+    headers?: HttpHeaders;
+}
+
+/**
+ * Abstract base class for feature services that interact with the API
+ *
+ * @remarks
  * Centralizes path resolution, default headers, and resilience patterns
  * (timeout, exponential-backoff retry on transient errors).
  *
  * Feature services extend this class, provide the base URL, and call
- * its typed methods:
+ * its typed methods. Only GET requests include the retry operator; mutating
+ * methods (POST, PUT, PATCH, DELETE) intentionally skip retries.
+ *
+ * Subclasses can override resilience values by redeclaring the class property.
+ *
+ * @usage
+ * Extend this class in feature services to inherit automatic timeout, retry,
+ * URL resolution, and default header behavior. Provide `baseUrl` and call
+ * the protected HTTP methods (get, post, put, patch, delete).
  *
  * @example
  * ```typescript
@@ -41,8 +100,6 @@ export interface TbxNgxHttpBodyRequestOptions {
  * }
  * ```
  *
- * Subclasses can override resilience values by redeclaring the class property:
- *
  * @example
  * ```typescript
  * export class SlowApiService extends TbxNgxBaseHttpService {
@@ -50,42 +107,99 @@ export interface TbxNgxHttpBodyRequestOptions {
  *     protected override readonly DEFAULT_TIMEOUT = 30_000;
  * }
  * ```
+ *
+ * @category Services
+ * @displayName Base HTTP Service
+ * @order 1
+ * @since 1.0.0
+ * @related TbxNgxHttpRequestOptions
+ * @related TbxNgxHttpBodyRequestOptions
+ * @related TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS
+ * @related TBX_NGX_HTTP_RETRY_COUNT
+ * @related TBX_NGX_HTTP_RETRY_DELAY_MS
+ * @related TBX_NGX_HTTP_RETRYABLE_STATUSES
+ *
+ * @public
  */
 export abstract class TbxNgxBaseHttpService {
+    /**
+     * Angular HttpClient instance injected via `inject()`
+     *
+     * @public
+     */
     protected readonly http = inject(HttpClient);
 
-    /** Base API URL — must be provided by the consuming application. */
+    /**
+     * Base API URL — must be provided by the consuming application
+     *
+     * @public
+     */
     protected abstract readonly baseUrl: string;
 
     /**
-     * Resilience configuration — sourced from http.constants.ts.
-     * Subclasses override by redeclaring the property; they do not need
-     * to import the constants file directly.
+     * Request timeout in milliseconds
+     *
+     * @remarks
+     * Defaults to {@link TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS}. Subclasses override
+     * by redeclaring the property.
+     *
+     * @public
      */
     protected readonly DEFAULT_TIMEOUT: number = TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS;
+
+    /**
+     * Number of retry attempts for GET requests
+     *
+     * @remarks
+     * Defaults to {@link TBX_NGX_HTTP_RETRY_COUNT}. Subclasses override
+     * by redeclaring the property.
+     *
+     * @public
+     */
     protected readonly RETRY_COUNT: number = TBX_NGX_HTTP_RETRY_COUNT;
+
+    /**
+     * Base delay in milliseconds for exponential backoff
+     *
+     * @remarks
+     * Defaults to {@link TBX_NGX_HTTP_RETRY_DELAY_MS}. Subclasses override
+     * by redeclaring the property.
+     *
+     * @public
+     */
     protected readonly RETRY_DELAY: number = TBX_NGX_HTTP_RETRY_DELAY_MS;
 
     /**
-     * Default headers applied to every request unless overridden per-call.
+     * Default headers applied to every request unless overridden per-call
      *
-     * Angular's HttpClient sets Content-Type: application/json automatically
-     * when the body is a JavaScript object. Accept is not set by default —
+     * @remarks
+     * Angular's HttpClient sets `Content-Type: application/json` automatically
+     * when the body is a JavaScript object. `Accept` is not set by default —
      * this header signals that the service speaks JSON.
      *
      * When a caller passes `options.headers`, the defaults are replaced
      * entirely (not merged). This keeps behavior predictable — if a caller
      * provides headers, they own the full set.
+     *
+     * @public
      */
     protected readonly defaultHeaders = new HttpHeaders({
         Accept: 'application/json',
     });
 
     /**
-     * Executes a GET request.
+     * Execute a GET request
      *
+     * @remarks
      * Includes retries with exponential backoff because GET is idempotent
      * and safe to repeat on transient failure (5xx, network errors).
+     *
+     * @typeParam T - Expected response body type.
+     * @param path - Relative path appended to {@link TbxNgxBaseHttpService.baseUrl | baseUrl}.
+     * @param options - Optional query parameters and headers.
+     * @returns An Observable emitting the typed response body.
+     *
+     * @public
      */
     protected get<T>(path: string, options?: TbxNgxHttpRequestOptions): Observable<T> {
         return this.http
@@ -97,8 +211,18 @@ export abstract class TbxNgxBaseHttpService {
     }
 
     /**
-     * Executes a POST request.
+     * Execute a POST request
+     *
+     * @remarks
      * Retries are disabled to prevent duplicate record creation (non-idempotent).
+     *
+     * @typeParam T - Expected response body type.
+     * @param path - Relative path appended to {@link TbxNgxBaseHttpService.baseUrl | baseUrl}.
+     * @param body - Request payload.
+     * @param options - Optional headers.
+     * @returns An Observable emitting the typed response body.
+     *
+     * @public
      */
     protected post<T>(
         path: string,
@@ -113,9 +237,19 @@ export abstract class TbxNgxBaseHttpService {
     }
 
     /**
-     * Executes a PUT request (full replacement).
+     * Execute a PUT request (full replacement)
+     *
+     * @remarks
      * Retries are disabled by default to maintain strict idempotency safety
      * across varying backend implementations.
+     *
+     * @typeParam T - Expected response body type.
+     * @param path - Relative path appended to {@link TbxNgxBaseHttpService.baseUrl | baseUrl}.
+     * @param body - Request payload.
+     * @param options - Optional headers.
+     * @returns An Observable emitting the typed response body.
+     *
+     * @public
      */
     protected put<T>(
         path: string,
@@ -130,8 +264,18 @@ export abstract class TbxNgxBaseHttpService {
     }
 
     /**
-     * Executes a PATCH request (partial update).
+     * Execute a PATCH request (partial update)
+     *
+     * @remarks
      * Retries are disabled as concurrent partial updates can lead to race conditions.
+     *
+     * @typeParam T - Expected response body type.
+     * @param path - Relative path appended to {@link TbxNgxBaseHttpService.baseUrl | baseUrl}.
+     * @param body - Request payload.
+     * @param options - Optional headers.
+     * @returns An Observable emitting the typed response body.
+     *
+     * @public
      */
     protected patch<T>(
         path: string,
@@ -146,9 +290,18 @@ export abstract class TbxNgxBaseHttpService {
     }
 
     /**
-     * Executes a DELETE request.
+     * Execute a DELETE request
+     *
+     * @remarks
      * Retries are disabled to avoid 404/410 errors on subsequent automated
      * attempts if the first request actually succeeded but the response was lost.
+     *
+     * @typeParam T - Expected response body type.
+     * @param path - Relative path appended to {@link TbxNgxBaseHttpService.baseUrl | baseUrl}.
+     * @param options - Optional query parameters and headers.
+     * @returns An Observable emitting the typed response body.
+     *
+     * @public
      */
     protected delete<T>(path: string, options?: TbxNgxHttpRequestOptions): Observable<T> {
         return this.http
@@ -159,32 +312,37 @@ export abstract class TbxNgxBaseHttpService {
             .pipe(timeout(this.DEFAULT_TIMEOUT));
     }
 
-    /** Resolves a relative path against the base URL. */
+    /**
+     * Resolve a relative path against the base URL.
+     *
+     * @param path - Relative path segment.
+     * @returns Fully qualified URL.
+     */
     private url(path: string): string {
         return `${this.baseUrl.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`;
     }
 
     /**
-     * Returns a custom RxJS operator configured with exponential backoff that
-     * only retries transient errors (status codes in TBX_NGX_HTTP_RETRYABLE_STATUSES).
+     * Return a custom RxJS retry operator with exponential backoff
      *
-     * Non-retryable errors (4xx client errors except 408/429) are re-thrown
-     * immediately — repeating a malformed request will not produce a
-     * different result.
+     * @remarks
+     * Only retries transient errors (status codes in
+     * {@link TBX_NGX_HTTP_RETRYABLE_STATUSES}). Non-retryable errors (4xx client
+     * errors except 408/429) are re-thrown immediately — repeating a malformed
+     * request will not produce a different result.
      *
-     * Note: non-HttpErrorResponse errors — including TimeoutError from the
-     * upstream timeout() operator — are always retried. This is intentional:
-     * GET requests are idempotent, and a timeout is a transient failure that
-     * may succeed on the next attempt. Mutating methods (POST, PUT, PATCH,
-     * DELETE) do not use this operator, so timeouts on those methods are
-     * never retried.
+     * Non-HttpErrorResponse errors — including `TimeoutError` from the upstream
+     * `timeout()` operator — are always retried. This is intentional: GET requests
+     * are idempotent, and a timeout is a transient failure that may succeed on the
+     * next attempt. Mutating methods (POST, PUT, PATCH, DELETE) do not use this
+     * operator, so timeouts on those methods are never retried.
      *
-     * Protected so subclasses can override the retry strategy or expose
-     * it for direct testing against controlled Observables.
+     * Backoff formula: `RETRY_DELAY * 2^(attempt - 1)`
      *
-     * Backoff formula: RETRY_DELAY × 2^(attempt - 1)
-     *   Attempt 1: 1 000 ms
-     *   Attempt 2: 2 000 ms
+     * @typeParam T - Observable element type.
+     * @returns An RxJS operator function that applies the retry strategy.
+     *
+     * @public
      */
     protected withRetry() {
         const count = this.RETRY_COUNT;

--- a/src/services/base-http.service.ts
+++ b/src/services/base-http.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { Observable, retry, throwError, timer, timeout } from 'rxjs';
 
@@ -9,66 +9,8 @@ import {
     TBX_NGX_HTTP_RETRYABLE_STATUSES,
 } from '../constants/http.constants';
 
-/**
- * Options accepted by non-body HTTP methods (GET, DELETE)
- *
- * @remarks
- * Passed as the optional second argument to
- * {@link TbxNgxBaseHttpService.get | get} and
- * {@link TbxNgxBaseHttpService.delete | delete}. When `headers` is provided,
- * the service's default headers are replaced entirely (not merged).
- *
- * @category Interfaces
- * @displayName HTTP Request Options
- * @order 2
- * @since 1.0.0
- * @related TbxNgxBaseHttpService
- * @related TbxNgxHttpBodyRequestOptions
- *
- * @public
- */
-export interface TbxNgxHttpRequestOptions {
-    /**
-     * Query parameters appended to the request URL
-     *
-     * @public
-     */
-    params?: HttpParams;
-    /**
-     * HTTP headers for the request, replaces default headers when provided
-     *
-     * @public
-     */
-    headers?: HttpHeaders;
-}
-
-/**
- * Options accepted by body HTTP methods (POST, PUT, PATCH)
- *
- * @remarks
- * Passed as the optional third argument to
- * {@link TbxNgxBaseHttpService.post | post},
- * {@link TbxNgxBaseHttpService.put | put}, and
- * {@link TbxNgxBaseHttpService.patch | patch}. When `headers` is provided,
- * the service's default headers are replaced entirely (not merged).
- *
- * @category Interfaces
- * @displayName HTTP Body Request Options
- * @order 3
- * @since 1.0.0
- * @related TbxNgxBaseHttpService
- * @related TbxNgxHttpRequestOptions
- *
- * @public
- */
-export interface TbxNgxHttpBodyRequestOptions {
-    /**
-     * HTTP headers for the request, replaces default headers when provided
-     *
-     * @public
-     */
-    headers?: HttpHeaders;
-}
+import type { TbxNgxHttpRequestOptions } from '../models/http-request-options.model';
+import type { TbxNgxHttpBodyRequestOptions } from '../models/http-body-request-options.model';
 
 /**
  * Abstract base class for feature services that interact with the API
@@ -91,7 +33,7 @@ export interface TbxNgxHttpBodyRequestOptions {
  * @example
  * ```typescript
  * @Injectable({ providedIn: 'root' })
- * export class UserService extends TbxNgxBaseHttpService {
+ * export class UserService extends TbxNgxHttpService {
  *     protected override readonly baseUrl = environment.apiUrl;
  *
  *     getUser(id: string) {
@@ -102,7 +44,7 @@ export interface TbxNgxHttpBodyRequestOptions {
  *
  * @example
  * ```typescript
- * export class SlowApiService extends TbxNgxBaseHttpService {
+ * export class SlowApiService extends TbxNgxHttpService {
  *     protected override readonly baseUrl = environment.apiUrl;
  *     protected override readonly DEFAULT_TIMEOUT = 30_000;
  * }
@@ -121,7 +63,7 @@ export interface TbxNgxHttpBodyRequestOptions {
  *
  * @public
  */
-export abstract class TbxNgxBaseHttpService {
+export abstract class TbxNgxHttpService {
     /**
      * Angular HttpClient instance injected via `inject()`
      *
@@ -195,7 +137,7 @@ export abstract class TbxNgxBaseHttpService {
      * and safe to repeat on transient failure (5xx, network errors).
      *
      * @typeParam T - Expected response body type.
-     * @param path - Relative path appended to {@link TbxNgxBaseHttpService.baseUrl | baseUrl}.
+     * @param path - Relative path appended to {@link TbxNgxHttpService.baseUrl | baseUrl}.
      * @param options - Optional query parameters and headers.
      * @returns An Observable emitting the typed response body.
      *
@@ -217,7 +159,7 @@ export abstract class TbxNgxBaseHttpService {
      * Retries are disabled to prevent duplicate record creation (non-idempotent).
      *
      * @typeParam T - Expected response body type.
-     * @param path - Relative path appended to {@link TbxNgxBaseHttpService.baseUrl | baseUrl}.
+     * @param path - Relative path appended to {@link TbxNgxHttpService.baseUrl | baseUrl}.
      * @param body - Request payload.
      * @param options - Optional headers.
      * @returns An Observable emitting the typed response body.
@@ -244,7 +186,7 @@ export abstract class TbxNgxBaseHttpService {
      * across varying backend implementations.
      *
      * @typeParam T - Expected response body type.
-     * @param path - Relative path appended to {@link TbxNgxBaseHttpService.baseUrl | baseUrl}.
+     * @param path - Relative path appended to {@link TbxNgxHttpService.baseUrl | baseUrl}.
      * @param body - Request payload.
      * @param options - Optional headers.
      * @returns An Observable emitting the typed response body.
@@ -270,7 +212,7 @@ export abstract class TbxNgxBaseHttpService {
      * Retries are disabled as concurrent partial updates can lead to race conditions.
      *
      * @typeParam T - Expected response body type.
-     * @param path - Relative path appended to {@link TbxNgxBaseHttpService.baseUrl | baseUrl}.
+     * @param path - Relative path appended to {@link TbxNgxHttpService.baseUrl | baseUrl}.
      * @param body - Request payload.
      * @param options - Optional headers.
      * @returns An Observable emitting the typed response body.
@@ -297,7 +239,7 @@ export abstract class TbxNgxBaseHttpService {
      * attempts if the first request actually succeeded but the response was lost.
      *
      * @typeParam T - Expected response body type.
-     * @param path - Relative path appended to {@link TbxNgxBaseHttpService.baseUrl | baseUrl}.
+     * @param path - Relative path appended to {@link TbxNgxHttpService.baseUrl | baseUrl}.
      * @param options - Optional query parameters and headers.
      * @returns An Observable emitting the typed response body.
      *

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "tagDefinitions": [
+    {
+      "tagName": "@category",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@since",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    },
+    {
+      "tagName": "@related",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@usage",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    },
+    {
+      "tagName": "@displayName",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    },
+    {
+      "tagName": "@order",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    }
+  ]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,10 +22,10 @@ export default defineConfig({
                 '**/vitest.config.ts',
                 '**/src/index.ts',
                 // Exclude constants from coverage since they contain no logic
-                '**/src/constants/http.constants.ts',
+                'src/constants/http.constants.ts',
                 // Exclude interfaces from coverage since they contain no logic
-                '**/src/models/http-request-options.model.ts',
-                '**/src/models/http-body-requestion-options.model.ts',
+                'src/models/http-request-options.model.ts',
+                'src/models/http-body-requestion-options.model.ts',
             ],
         },
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,17 @@ export default defineConfig({
                 branches: 75,
                 perFile: true,
             },
+            exclude: [
+                '**/test-setup.ts',
+                '**/*.spec.ts',
+                '**/vitest.config.ts',
+                '**/src/index.ts',
+                // Exclude constants from coverage since they contain no logic
+                '**/src/constants/http.constants.ts',
+                // Exclude interfaces from coverage since they contain no logic
+                '**/src/models/http-request-options.model.ts',
+                '**/src/models/http-body-requestion-options.model.ts',
+            ],
         },
     },
 });


### PR DESCRIPTION
## Summary
- Extract interfaces to dedicated files and rename `TbxNgxBaseHttpService` to `TbxNgxHttpService`
- Add TSDoc tooling (`eslint-plugin-tsdoc`, `tsdoc.json`) and migrate all exported declarations to TSDoc comments
- Add hyperlinks to official sources for external technologies across CLAUDE.md and README
- Add feedback section to README with links to issue templates

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] `npm run build` produces valid APF output
- [x] Renamed service (`TbxNgxHttpService`) exports correctly from barrel file

🤖 Generated with [Claude Code](https://claude.com/claude-code)