### PR TITLE
docs(conventions): apply external linking, AI friendliness, and TSDoc fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,78 @@ Top-level exports: summary line → `@remarks` → `@typeParam` / `@param` / `@r
 
 Members (properties, methods): summary line → `@remarks` → `@param` / `@returns` (methods only) → `@order` → `@public` / `@internal`
 
+### Reference Implementation
+
+`@teqbench/tbx-models` (a separate repository) `src/base-model.ts` is the reference for a fully migrated [TSDoc ↗](https://tsdoc.org) comment on an interface with member-level docs including `@order` tags. `src/index.ts` in that same package is the reference for a `@packageDocumentation` barrel file [TSDoc ↗](https://tsdoc.org) comment. These files are not accessible from this repository — clone `@teqbench/tbx-models` separately to view them.
+
+### Verification
+
+After migration, run `npm run lint` and confirm no `tsdoc/syntax` warnings. Run `npm run format:check` and `npm test` to ensure nothing broke.
+
+## External Linking Convention
+
+Every prose mention of an external specification, standard, or technology in documentation must be hyperlinked to its official source. This applies to all markdown files (.md) and all [TSDoc ↗](https://tsdoc.org) comments in [TypeScript ↗](https://www.typescriptlang.org) source files (.ts). Exclude CHANGELOG.md, git submodules, and build output directories.
+
+### Format
+
+- **Markdown:** `[Name ↗](url)` with the ↗ (U+2197) character inside the link text for external resources. Internal/relative links do not use ↗.
+- **TSDoc:** `{@link url | Name}` inline syntax in every section where an external technology appears — summary, `@remarks`, `@usage`, `@param`, `@returns`, and member-level docs. For each distinct external resource referenced in a top-level export's summary, add a `@see {@link url | Name}` tag in the tag section.
+
+### Rules
+
+- Link to the official specification or project homepage, not Wikipedia or third-party summaries.
+- Use canonical names (e.g., "ISO 8601" not "ISO-8601").
+- Internal references and cross-references to other `@teqbench` packages use relative links or `{@link ExportName}` without ↗.
+- Link every prose mention, not just the first occurrence per document.
+- Do not place links inside backtick code spans or section headings.
+- License references link to the project's own LICENSE file using a relative path, without ↗.
+- [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) links use the org packages page, not the generic feature page.
+- Project-specific service instances (badge gist, org packages page, issue templates) link to the actual instance URL, not the generic service homepage. Discover URLs from README badge URLs, workflow files, `package.json`, and config files.
+
+### SECURITY.md Reporting Channel
+
+- **Private repository:** Email link (`[info@teqbench.dev](mailto:info@teqbench.dev)`). GitHub Private vulnerability reporting is not available without GitHub Advanced Security.
+- **Public repository:** [GitHub Private vulnerability reporting ↗](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) via `/security/advisories/new`. Enable at the org level if available, otherwise at the repo level.
+- When transitioning a repo from private to public, update SECURITY.md to switch from email to the advisory URL.
+
+### README Requirements
+
+The README must have a "Feedback" section immediately above "License" with links to Bug Report and Feature Request issue templates using the `issues/new?template=` URL pattern.
+
+## AI Friendliness Convention
+
+All [TSDoc ↗](https://tsdoc.org) comments, inline code comments, and markdown files must be written for AI consumption — documentation generators, code assistants, and retrieval-augmented generation systems parse these to answer questions, generate docs, or suggest code.
+
+### Disambiguation
+
+- Every `{@link ExportName}` must resolve to an export in the current package. References to external types must include a full URL: `{@link https://angular.dev/api/core/ClassName | ClassName}`.
+- Barrel file grouping comments (e.g., `// Models`, `// Services`) must match the `@category` tags on the exports they group.
+- `@category Interface` is reserved for [TypeScript ↗](https://www.typescriptlang.org) `interface` declarations. Abstract classes serving as DI tokens or extension points use `@category Contract`.
+
+### Context Completeness
+
+- Do not imply auto-registration. If consumers must explicitly provide an implementation via DI, say so. Do not write "default implementation" without clarifying that no provider is registered automatically.
+- Optional fields the pipeline never populates must state that explicitly (e.g., "the pipeline never sets this field; set it when constructing a context manually").
+- Methods with error-handling behavior (try/catch, swallowing, fallback) must document it in `@remarks`.
+- Hypothetical class names in `@example` blocks must include a comment identifying them as consumer-defined placeholders (e.g., `// SentryErrorLogger is a hypothetical consumer-defined subclass`).
+- References to files or configurations in other repositories must note they are external and not accessible from the current repo.
+
+### Structural Consistency
+
+- Every exported class and function must have an `@example` tag.
+- Do not duplicate the same URL in both an inline `{@link}` and a `@see` tag on the same member.
+- `@internal` members must have a summary line before the tag.
+- `@returns` is required for non-void returns; omit for `void`.
+- Summary lines must lead with the primary action matching the export name (e.g., `logClientError` summarizes as "Log a manually caught error..." not "Build a structured error context...").
+
+### Semantic Clarity
+
+- Do not use terms with established technical meanings in unintended ways (e.g., "side-effect pattern" for fan-out, "structured output" for human-readable console logging).
+- Do not reference concepts or patterns that do not exist in the codebase.
+- Coverage pragmas (`/* v8 ignore next */`) and other non-obvious annotations must be documented in this file (see Publishing section).
+- Configuration snapshots in documentation must note they are examples that may not reflect the current state.
+- Custom `package.json` metadata fields (not defined by the [npm ↗](https://www.npmjs.com) spec) must be identified as custom where referenced.
+
 ## Commit Convention
 
 Follow **[Conventional Commits ↗](https://conventionalcommits.org/)** strictly:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ### Node.js
 
-Install the version specified in `.nvmrc` (Node 24+). If you use nvm:
+Install the version specified in `.nvmrc` ([Node.js ↗](https://nodejs.org/) 24+). If you use nvm:
 
 ```bash
 nvm install
@@ -13,7 +13,7 @@ nvm use
 
 ### GitHub Packages Authentication
 
-This package depends on `@teqbench` scoped packages hosted on GitHub Packages. To install them locally, you need a GitHub personal access token (PAT) with `read:packages` scope.
+This package depends on `@teqbench` scoped packages hosted on [GitHub Packages ↗](https://github.com/orgs/teqbench/packages). To install them locally, you need a GitHub personal access token (PAT) with `read:packages` scope.
 
 1. Create a PAT at **GitHub > Settings > Developer settings > Personal access tokens** with `read:packages` scope
 2. Add it to your shell profile (`~/.zshrc` or `~/.bashrc`):
@@ -26,20 +26,20 @@ This package depends on `@teqbench` scoped packages hosted on GitHub Packages. T
     ```
 4. Open a new terminal (or `source ~/.zshrc`) and verify: `npm ci`
 
-The repo `.npmrc` already configures the `@teqbench` scope to use GitHub Packages. The `~/.npmrc` auth line tells npm how to authenticate. CI handles this separately via `actions/setup-node`.
+The repo `.npmrc` already configures the `@teqbench` scope to use [GitHub Packages ↗](https://github.com/orgs/teqbench/packages). The `~/.npmrc` auth line tells npm how to authenticate. CI handles this separately via `actions/setup-node`.
 
 #### Cross-repo package access (CI)
 
-If this package depends on other `@teqbench` packages, each package in the entire dependency tree (direct and transitive) must grant this repository read access on GitHub. For each `@teqbench` package, go to **github.com/orgs/teqbench/packages/npm/\<package-name\>/settings → Manage access**, add this repository, and set the role to **Read**. GitHub Packages has its own access control layer — repository and app permissions alone are not sufficient. Without this, CI will fail with `403 Forbidden` during `npm ci`. For example, if this package depends on `tbx-mat-severity-icons` which depends on `tbx-mat-icons`, you must grant read access on both packages.
+If this package depends on other `@teqbench` packages, each package in the entire dependency tree (direct and transitive) must grant this repository read access on GitHub. For each `@teqbench` package, go to **github.com/orgs/teqbench/packages/npm/\<package-name\>/settings → Manage access**, add this repository, and set the role to **Read**. [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) has its own access control layer — repository and app permissions alone are not sufficient. Without this, CI will fail with `403 Forbidden` during `npm ci`. For example, if this package depends on `tbx-mat-severity-icons` which depends on `tbx-mat-icons`, you must grant read access on both packages.
 
 ## Tech Stack
 
-- **Language:** [TypeScript](https://www.typescriptlang.org) 5.9+
-- **Testing:** [Vitest](https://vitest.dev)
-- **Linting:** [ESLint](https://eslint.org) (Flat Config)
-- **Formatting:** [Prettier](https://prettier.io) (enforced via pre-commit hook and CI)
-- **Git Hooks:** Husky + lint-staged (runs Prettier on staged files before every commit)
-- **Versioning:** [Release Please](https://github.com/googleapis/release-please) (Conventional Commits)
+- **Language:** [TypeScript ↗](https://www.typescriptlang.org) 5.9+
+- **Testing:** [Vitest ↗](https://vitest.dev)
+- **Linting:** [ESLint ↗](https://eslint.org) (Flat Config)
+- **Formatting:** [Prettier ↗](https://prettier.io) (enforced via pre-commit hook and CI)
+- **Git Hooks:** [Husky ↗](https://typicode.github.io/husky/) + [lint-staged ↗](https://github.com/lint-staged/lint-staged) (runs Prettier on staged files before every commit)
+- **Versioning:** [Release Please ↗](https://github.com/googleapis/release-please) ([Conventional Commits ↗](https://conventionalcommits.org/))
 
 ## Key Commands
 
@@ -54,7 +54,7 @@ If this package depends on other `@teqbench` packages, each package in the entir
 
 ## Commit Convention
 
-Follow **[Conventional Commits](https://www.conventionalcommits.org)** strictly. Release Please uses these to determine version bumps.
+Follow **[Conventional Commits ↗](https://conventionalcommits.org/)** strictly. Release Please uses these to determine version bumps.
 
 - `feat(scope): ...` — New feature (minor version bump)
 - `fix(scope): ...` — Bug fix (patch version bump)
@@ -97,7 +97,7 @@ Follow **[Conventional Commits](https://www.conventionalcommits.org)** strictly.
 2. Merge `main` into the release branch to resolve any conflicts (especially badge files)
 3. Open a PR from the release branch to `main`
 4. After merge, Release Please opens a version bump PR on `main`
-5. Merge the Release Please PR to trigger a GitHub Release and publish to GitHub Packages
+5. Merge the Release Please PR to trigger a GitHub Release and publish to [GitHub Packages ↗](https://github.com/orgs/teqbench/packages)
 6. The sync workflow automatically merges `main` back into `dev`
 
 For details on how the CI/CD pipelines work, see [docs/reference/workflows/](docs/reference/workflows/).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Installation
 
-Configure npm to use GitHub Packages for the `@teqbench` scope:
+Configure npm to use [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) for the `@teqbench` scope:
 
 ```bash
 echo "@teqbench:registry=https://npm.pkg.github.com" >> .npmrc

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ The latest version on `main` is the only supported version.
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-To report a vulnerability, open a [GitHub Security Advisory](https://github.com/teqbench/tbx-ngx-http/security/advisories/new) via the **Security** tab of this repository. This keeps the report private until a fix is available.
+To report a vulnerability, open a [GitHub Security Advisory ↗](https://github.com/teqbench/tbx-ngx-http/security/advisories/new) via the **Security** tab of this repository. This keeps the report private until a fix is available.
 
 Include as much of the following as possible:
 

--- a/src/models/http-body-request-options.model.ts
+++ b/src/models/http-body-request-options.model.ts
@@ -10,7 +10,21 @@ import { HttpHeaders } from '@angular/common/http';
  * {@link TbxNgxHttpService.patch | patch}. When `headers` is provided,
  * the service's default headers are replaced entirely (not merged).
  *
- * @category Interfaces
+ * @usage
+ * Pass an instance of this interface to customize headers on POST, PUT, and
+ * PATCH requests made through {@link TbxNgxHttpService}.
+ *
+ * @example
+ * ```typescript
+ * import { HttpHeaders } from '@angular/common/http';
+ * import { TbxNgxHttpBodyRequestOptions } from '@teqbench/tbx-ngx-http';
+ *
+ * const options: TbxNgxHttpBodyRequestOptions = {
+ *     headers: new HttpHeaders({ Authorization: 'Bearer token' }),
+ * };
+ * ```
+ *
+ * @category Interface
  * @displayName HTTP Body Request Options
  * @order 3
  * @since 1.0.0
@@ -21,7 +35,7 @@ import { HttpHeaders } from '@angular/common/http';
  */
 export interface TbxNgxHttpBodyRequestOptions {
     /**
-     * HTTP headers for the request, replaces default headers when provided
+     * {@link https://angular.dev/api/common/http/HttpHeaders | HttpHeaders} for the request, replaces default headers when provided
      *
      * @public
      */

--- a/src/models/http-request-options.model.ts
+++ b/src/models/http-request-options.model.ts
@@ -9,7 +9,21 @@ import { HttpHeaders, HttpParams } from '@angular/common/http';
  * {@link TbxNgxHttpService.delete | delete}. When `headers` is provided,
  * the service's default headers are replaced entirely (not merged).
  *
- * @category Interfaces
+ * @usage
+ * Pass an instance of this interface to customize query parameters or headers
+ * on GET and DELETE requests made through {@link TbxNgxHttpService}.
+ *
+ * @example
+ * ```typescript
+ * import { HttpParams } from '@angular/common/http';
+ * import { TbxNgxHttpRequestOptions } from '@teqbench/tbx-ngx-http';
+ *
+ * const options: TbxNgxHttpRequestOptions = {
+ *     params: new HttpParams().set('page', '1'),
+ * };
+ * ```
+ *
+ * @category Interface
  * @displayName HTTP Request Options
  * @order 2
  * @since 1.0.0
@@ -26,7 +40,7 @@ export interface TbxNgxHttpRequestOptions {
      */
     params?: HttpParams;
     /**
-     * HTTP headers for the request, replaces default headers when provided
+     * {@link https://angular.dev/api/common/http/HttpHeaders | HttpHeaders} for the request, replaces default headers when provided
      *
      * @public
      */

--- a/src/services/base-http.service.ts
+++ b/src/services/base-http.service.ts
@@ -65,7 +65,7 @@ import type { TbxNgxHttpBodyRequestOptions } from '../models/http-body-request-o
  */
 export abstract class TbxNgxHttpService {
     /**
-     * Angular HttpClient instance injected via `inject()`
+     * {@link https://angular.dev/api/common/http/HttpClient | HttpClient} instance injected via {@link https://angular.dev/api/core/inject | inject()}
      *
      * @public
      */
@@ -115,7 +115,7 @@ export abstract class TbxNgxHttpService {
      * Default headers applied to every request unless overridden per-call
      *
      * @remarks
-     * Angular's HttpClient sets `Content-Type: application/json` automatically
+     * {@link https://angular.dev/api/common/http/HttpClient | HttpClient} sets `Content-Type: application/json` automatically
      * when the body is a JavaScript object. `Accept` is not set by default —
      * this header signals that the service speaks JSON.
      *


### PR DESCRIPTION
## Summary

- Add ↗ character to all external links in CONTRIBUTING.md, SECURITY.md, and README.md per the external linking convention
- Add missing hyperlinks for Husky, lint-staged, GitHub Packages, and Node.js in CONTRIBUTING.md
- Fix `@category Interfaces` → `@category Interface` on model interfaces per AI friendliness convention
- Add `@usage` and `@example` tags to `TbxNgxHttpRequestOptions` and `TbxNgxHttpBodyRequestOptions`
- Add Angular `{@link}` URLs for `HttpClient`, `HttpHeaders`, and `inject()` prose mentions in TSDoc

## Test plan

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm test` passes (47/47)

🤖 Generated with [Claude Code](https://claude.com/claude-code)