### PR TITLE
docs(links): complete external link verification across all files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ Closes #
 ## Checklist
 
 - [ ] My branch is based on `dev` (or `main` for hotfixes)
-- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
+- [ ] Commit messages follow [Conventional Commits ↗](https://conventionalcommits.org/)
 - [ ] `npm run format:check` passes
 - [ ] `npm run typecheck` passes
 - [ ] `npm run lint` passes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance for Claude Code when working in this repository.
+This file provides guidance for [Claude Code ↗](https://github.com/anthropics/claude-code) when working in this repository.
 
 ## Package Overview
 
@@ -160,7 +160,7 @@ Every prose mention of an external specification, standard, or technology in doc
 ### Format
 
 - **Markdown:** `[Name ↗](url)` with the ↗ (U+2197) character inside the link text for external resources. Internal/relative links do not use ↗.
-- **TSDoc:** `{@link url | Name}` inline syntax in every section where an external technology appears — summary, `@remarks`, `@usage`, `@param`, `@returns`, and member-level docs. For each distinct external resource referenced in a top-level export's summary, add a `@see {@link url | Name}` tag in the tag section.
+- **[TSDoc ↗](https://tsdoc.org/):** `{@link url | Name}` inline syntax in every section where an external technology appears — summary, `@remarks`, `@usage`, `@param`, `@returns`, and member-level docs. For each distinct external resource referenced in a top-level export's summary, add a `@see {@link url | Name}` tag in the tag section.
 
 ### Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance for Claude Code when working in this repository.
 
 ## Package Overview
 
-This is `@teqbench/tbx-ngx-http`, an Angular library providing base HTTP communication services and resilience constants. It offers an abstract `TbxNgxHttpService` that feature services extend to get automatic retries with exponential backoff on GET requests, timeout handling, consistent URL resolution, and default headers. Resilience constants (`TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS`, `TBX_NGX_HTTP_RETRY_COUNT`, `TBX_NGX_HTTP_RETRY_DELAY_MS`, `TBX_NGX_HTTP_RETRYABLE_STATUSES`) are exported for direct use.
+This is `@teqbench/tbx-ngx-http`, an [Angular ↗](https://angular.dev/) library providing base HTTP communication services and resilience constants. It offers an abstract `TbxNgxHttpService` that feature services extend to get automatic retries with exponential backoff on GET requests, timeout handling, consistent URL resolution, and default headers. Resilience constants (`TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS`, `TBX_NGX_HTTP_RETRY_COUNT`, `TBX_NGX_HTTP_RETRY_DELAY_MS`, `TBX_NGX_HTTP_RETRYABLE_STATUSES`) are exported for direct use.
 
 ## Tech Stack
 
@@ -12,19 +12,19 @@ This is `@teqbench/tbx-ngx-http`, an Angular library providing base HTTP communi
 - **Testing:** [Vitest ↗](https://vitest.dev/) (globals enabled)
 - **Linting:** [ESLint ↗](https://eslint.org/) flat config with typescript-eslint
 - **Formatting:** [Prettier ↗](https://prettier.io/) (enforced via pre-commit hook and CI)
-- **Git Hooks:** [Husky ↗](https://typicode.github.io/husky/) + [lint-staged ↗](https://github.com/okonet/lint-staged)
+- **Git Hooks:** [Husky ↗](https://typicode.github.io/husky/) + [lint-staged ↗](https://github.com/lint-staged/lint-staged)
 - **Versioning:** [Release Please ↗](https://github.com/googleapis/release-please) ([Conventional Commits ↗](https://conventionalcommits.org/))
 - **Registry:** [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) (`@teqbench` scope)
 
 ## Key Commands
 
 - `npm ci` — Install dependencies (use this, not `npm install`)
-- `npm run build` — Compile TypeScript to `dist/`
-- `npm test` — Run tests with Vitest
+- `npm run build` — Compile [TypeScript ↗](https://www.typescriptlang.org/) to `dist/`
+- `npm test` — Run tests with [Vitest ↗](https://vitest.dev/)
 - `npm run test:coverage` — Run tests with coverage enforcement (used in CI)
-- `npm run typecheck` — Full TypeScript type-check (`tsc --noEmit`)
-- `npm run lint` — Run ESLint
-- `npm run format` — Format all files with Prettier
+- `npm run typecheck` — Full [TypeScript ↗](https://www.typescriptlang.org/) type-check (`tsc --noEmit`)
+- `npm run lint` — Run [ESLint ↗](https://eslint.org/)
+- `npm run format` — Format all files with [Prettier ↗](https://prettier.io/)
 - `npm run format:check` — Check formatting (CI mode)
 
 ## Project Structure
@@ -38,13 +38,13 @@ This is `@teqbench/tbx-ngx-http`, an Angular library providing base HTTP communi
 
 ## Publishing
 
-- Packages are published to GitHub Packages (`@teqbench` scope) via the release workflow.
+- Packages are published to [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) (`@teqbench` scope) via the release workflow.
 - Coverage thresholds are enforced in CI: 80% lines/functions/statements, 75% branches, per file.
-- **Build tooling:** [ng-packagr ↗](https://github.com/ng-packagr/ng-packagr) is used to build [Angular Package Format ↗](https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/edit) (APF) output. It uses bundler module resolution internally, so source files use extensionless relative imports (e.g., `'./foo.service'`). The `ng-package.json` at the repo root configures the entry point and output directory. ng-packagr generates its own `package.json` inside `dist/` with the correct APF entry points (`module`, `types`, `exports`). The release workflow publishes from `dist/` (`npm publish ./dist`) so consumers resolve against ng-packagr's `package.json` directly — the root `package.json` does not need `main`, `types`, or `exports` fields.
+- **Build tooling:** [ng-packagr ↗](https://github.com/ng-packagr/ng-packagr) is used to build [Angular Package Format ↗](https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/edit) (APF) output. It uses bundler module resolution internally, so source files use extensionless relative imports (e.g., `'./foo.service'`). The `ng-package.json` at the repo root configures the entry point and output directory. [ng-packagr ↗](https://github.com/ng-packagr/ng-packagr) generates its own `package.json` inside `dist/` with the correct APF entry points (`module`, `types`, `exports`). The release workflow publishes from `dist/` (`npm publish ./dist`) so consumers resolve against [ng-packagr ↗](https://github.com/ng-packagr/ng-packagr)'s `package.json` directly — the root `package.json` does not need `main`, `types`, or `exports` fields.
 
-## [TSDoc ↗](https://tsdoc.org/) Convention
+## TSDoc Convention
 
-All exported TypeScript declarations must have TSDoc comments validated by `eslint-plugin-tsdoc`. Custom tags are defined in `tsdoc.json` and consumed downstream by [API Extractor ↗](https://api-extractor.com/) and the AI HTML documentation generator.
+All exported [TypeScript ↗](https://www.typescriptlang.org/) declarations must have [TSDoc ↗](https://tsdoc.org/) comments validated by `eslint-plugin-tsdoc`. Custom tags are defined in `tsdoc.json` and consumed downstream by [API Extractor ↗](https://api-extractor.com/) and the AI HTML documentation generator.
 
 ### Standard Tags (always use)
 
@@ -52,7 +52,7 @@ All exported TypeScript declarations must have TSDoc comments validated by `esli
 - `@typeParam` — Document generic type parameters (not `@template`).
 - `@param` — Document function/method parameters.
 - `@returns` — Document return values.
-- `@example` — Code examples in fenced TypeScript blocks.
+- `@example` — Code examples in fenced [TypeScript ↗](https://www.typescriptlang.org/) blocks.
 - `@public` / `@internal` — Release tag on every export. Use `@public` unless the export is not part of the package API surface.
 - `@packageDocumentation` — Required on every barrel file (`index.ts`) to describe the package entry point. Use `{@link ExportName}` to cross-reference primary exports.
 - `@see` — Reference to related external resources or docs.
@@ -139,7 +139,7 @@ Member-level comment structure (properties, methods):
 
 ### Tag Ordering
 
-Follow this order within a TSDoc comment:
+Follow this order within a [TSDoc ↗](https://tsdoc.org/) comment:
 
 Top-level exports: summary line → `@remarks` → `@typeParam` / `@param` / `@returns` → `@usage` → `@example` → `@category` (repeatable) → `@displayName` → `@order` → `@since` → `@related` (repeatable) → `@public` / `@internal`
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -115,16 +115,16 @@ community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+This Code of Conduct is adapted from the [Contributor Covenant ↗][homepage],
 version 2.1, available at
-[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html ↗][v2.1].
 
 Community Impact Guidelines were inspired by
-[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+[Mozilla's code of conduct enforcement ladder ↗][Mozilla CoC].
 
 For answers to common questions about this code of conduct, see the FAQ at
-[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
-[https://www.contributor-covenant.org/translations][translations].
+[https://www.contributor-covenant.org/faq ↗][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations ↗][translations].
 
 [homepage]: https://www.contributor-covenant.org
 [v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ### Node.js
 
-Install the version specified in `.nvmrc` ([Node.js ↗](https://nodejs.org/) 24+). If you use nvm:
+Install the version specified in `.nvmrc` ([Node.js ↗](https://nodejs.org/) 24+). If you use [nvm ↗](https://github.com/nvm-sh/nvm):
 
 ```bash
 nvm install
@@ -47,14 +47,14 @@ If this package depends on other `@teqbench` packages, each package in the entir
 - `npm run build` — Build the package
 - `npm test` — Run tests
 - `npm run test:coverage` — Run tests with coverage enforcement
-- `npm run typecheck` — Full TypeScript type-check
-- `npm run lint` — Run ESLint checks
-- `npm run format` — Format all files with Prettier
+- `npm run typecheck` — Full [TypeScript ↗](https://www.typescriptlang.org/) type-check
+- `npm run lint` — Run [ESLint ↗](https://eslint.org/) checks
+- `npm run format` — Format all files with [Prettier ↗](https://prettier.io/)
 - `npm run format:check` — Check formatting without writing (used in CI)
 
 ## Commit Convention
 
-Follow **[Conventional Commits ↗](https://conventionalcommits.org/)** strictly. Release Please uses these to determine version bumps.
+Follow **[Conventional Commits ↗](https://conventionalcommits.org/)** strictly. [Release Please ↗](https://github.com/googleapis/release-please) uses these to determine version bumps.
 
 - `feat(scope): ...` — New feature (minor version bump)
 - `fix(scope): ...` — Bug fix (patch version bump)
@@ -96,7 +96,7 @@ Follow **[Conventional Commits ↗](https://conventionalcommits.org/)** strictly
 1. Create a `release/*` branch from `dev`
 2. Merge `main` into the release branch to resolve any conflicts (especially badge files)
 3. Open a PR from the release branch to `main`
-4. After merge, Release Please opens a version bump PR on `main`
+4. After merge, [Release Please ↗](https://github.com/googleapis/release-please) opens a version bump PR on `main`
 5. Merge the Release Please PR to trigger a GitHub Release and publish to [GitHub Packages ↗](https://github.com/orgs/teqbench/packages)
 6. The sync workflow automatically merges `main` back into `dev`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ Follow **[Conventional Commits ↗](https://conventionalcommits.org/)** strictly
 2. Merge `main` into the release branch to resolve any conflicts (especially badge files)
 3. Open a PR from the release branch to `main`
 4. After merge, [Release Please ↗](https://github.com/googleapis/release-please) opens a version bump PR on `main`
-5. Merge the Release Please PR to trigger a GitHub Release and publish to [GitHub Packages ↗](https://github.com/orgs/teqbench/packages)
+5. Merge the [Release Please ↗](https://github.com/googleapis/release-please) PR to trigger a GitHub Release and publish to [GitHub Packages ↗](https://github.com/orgs/teqbench/packages)
 6. The sync workflow automatically merges `main` back into `dev`
 
 For details on how the CI/CD pipelines work, see [docs/reference/workflows/](docs/reference/workflows/).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Build Status](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-ngx-http-main-build-status.json) ![Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-ngx-http-main-tests.json) ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-ngx-http-main-coverage.json) ![Version](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-ngx-http-main-version.json) ![Build Number](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-ngx-http-main-build-number.json)
 
-> Base HTTP communication services and resilience constants for Angular. Provides automatic retries with exponential backoff, timeout handling, and consistent URL resolution for feature services.
+> Base HTTP communication services and resilience constants for [Angular ↗](https://angular.dev/). Provides automatic retries with exponential backoff, timeout handling, and consistent URL resolution for feature services.
 
 ## Installation
 

--- a/docs/reference/workflows/ci.md
+++ b/docs/reference/workflows/ci.md
@@ -89,11 +89,11 @@ with:
     fetch-depth: 0
 ```
 
-Uses the app token when available. Falls back to `GITHUB_TOKEN` for [Dependabot ↗](https://docs.github.com/en/code-security/dependabot) PRs. Submodules (Claude Code skills) are checked out for non-Dependabot runs. `fetch-depth: 0` fetches full history.
+Uses the app token when available. Falls back to `GITHUB_TOKEN` for [Dependabot ↗](https://docs.github.com/en/code-security/dependabot) PRs. Submodules ([Claude Code ↗](https://github.com/anthropics/claude-code) skills) are checked out for non-Dependabot runs. `fetch-depth: 0` fetches full history.
 
 #### 4. Setup Node
 
-Reads the Node version from `.nvmrc` with npm cache enabled.
+Reads the Node version from `.nvmrc` with [npm ↗](https://www.npmjs.com/) cache enabled.
 
 #### 5. Install Dependencies
 

--- a/docs/reference/workflows/ci.md
+++ b/docs/reference/workflows/ci.md
@@ -167,7 +167,7 @@ Compares the [TypeScript ↗](https://www.typescriptlang.org/) and [Node.js ↗]
 npm run build
 ```
 
-Compiles TypeScript to `dist/` using `tsconfig.build.json`.
+Compiles [TypeScript ↗](https://www.typescriptlang.org/) to `dist/` using `tsconfig.build.json`.
 
 #### 14–18. Push Badge Data to Gist
 

--- a/docs/reference/workflows/claude.md
+++ b/docs/reference/workflows/claude.md
@@ -1,13 +1,13 @@
 # Claude Code Workflow — `claude.yml`
 
-**Full name:** TeqBench Package - Claude Code Workflow
+**Full name:** TeqBench Package - [Claude Code ↗](https://github.com/anthropics/claude-code) Workflow
 **File:** `.github/workflows/claude.yml`
 
 ---
 
 ## Purpose
 
-The Claude Code workflow provides AI-powered assistance directly in GitHub issues and pull requests. When a user mentions `@claude` in a comment or issue body, Claude reads the codebase, analyzes the request, and can implement features, fix bugs, review code, or create pull requests — all within the GitHub UI.
+The [Claude Code ↗](https://github.com/anthropics/claude-code) workflow provides AI-powered assistance directly in GitHub issues and pull requests. When a user mentions `@claude` in a comment or issue body, Claude reads the codebase, analyzes the request, and can implement features, fix bugs, review code, or create pull requests — all within the GitHub UI.
 
 ---
 
@@ -56,7 +56,7 @@ jobs:
 | `APP_PRIVATE_KEY`   | GitHub App private key                                                                      |
 | `ANTHROPIC_API_KEY` | Authenticates with the [Anthropic API ↗](https://docs.anthropic.com/en/api/getting-started) |
 
-The app token is used for checkout with submodules (Claude Code skills) and for full repository access.
+The app token is used for checkout with submodules ([Claude Code ↗](https://github.com/anthropics/claude-code) skills) and for full repository access.
 
 ---
 
@@ -173,7 +173,7 @@ Claude reads the `CLAUDE.md` file in the repo root for project-specific context.
 - Branching rules and workflow expectations
 - Explicit do's and don'ts for Claude's behavior
 
-Both the GitHub Action and the Claude Code CLI read the same `CLAUDE.md`, ensuring consistent behavior across local and CI environments.
+Both the GitHub Action and the [Claude Code ↗](https://github.com/anthropics/claude-code) CLI read the same `CLAUDE.md`, ensuring consistent behavior across local and CI environments.
 
 ---
 

--- a/docs/reference/workflows/dep-compat-check.md
+++ b/docs/reference/workflows/dep-compat-check.md
@@ -37,7 +37,7 @@ Only needs write access to issues for posting status comments.
 | -------------- | --------------------------- |
 | `GITHUB_TOKEN` | Default token for API calls |
 
-No app token needed — this workflow only reads the npm registry and writes issue comments.
+No app token needed — this workflow only reads the [npm ↗](https://www.npmjs.com/) registry and writes issue comments.
 
 ---
 
@@ -62,7 +62,7 @@ also-track: @angular/cli, @angular/compiler
 
 | Field         | Required | Description                                                       |
 | ------------- | -------- | ----------------------------------------------------------------- |
-| `package`     | Yes      | npm package name to check                                         |
+| `package`     | Yes      | [npm ↗](https://www.npmjs.com/) package name to check             |
 | `resolution`  | No       | Resolution condition (see below). Defaults to `manual`.           |
 | `description` | No       | Human-readable context for status reports                         |
 | `also-track`  | No       | Comma-separated list of additional packages to show in the report |

--- a/docs/reference/workflows/release.md
+++ b/docs/reference/workflows/release.md
@@ -7,7 +7,7 @@
 
 ## Purpose
 
-The Release workflow automates versioning, changelog generation, GitHub Release creation, and npm publishing using Google's [Release Please ↗](https://github.com/googleapis/release-please). It eliminates the need to manually edit version numbers, write changelogs, or create release tags. When a release is created, the package is automatically published to GitHub Packages.
+The Release workflow automates versioning, changelog generation, GitHub Release creation, and npm publishing using Google's [Release Please ↗](https://github.com/googleapis/release-please). It eliminates the need to manually edit version numbers, write changelogs, or create release tags. When a release is created, the package is automatically published to [GitHub Packages ↗](https://github.com/orgs/teqbench/packages).
 
 ---
 
@@ -103,7 +103,7 @@ permissions:
 1. **Checkout code** — Standard checkout (no full history needed).
 2. **Setup Node** — Configures Node from `.nvmrc` with `registry-url: "https://npm.pkg.github.com"` for [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) authentication.
 3. **Install dependencies** — `npm ci` for deterministic builds. `GITHUB_TOKEN` with `packages: write` handles publishing to the current repo's package, and `packages: read` (inherited) handles installing dependencies.
-4. **Build** — `npm run build` compiles TypeScript to `dist/`.
+4. **Build** — `npm run build` compiles [TypeScript ↗](https://www.typescriptlang.org/) to `dist/`.
 5. **Publish** — `npm publish` with `NODE_AUTH_TOKEN` set to `GITHUB_TOKEN`. The `"files": ["dist"]` field in `package.json` ensures only compiled output is included.
 
 > **Cross-repo `@teqbench` dependencies:** For packages that depend on other `@teqbench` packages, each dependency package must grant the consuming repository read access in its package settings (**[GitHub Packages ↗](https://github.com/orgs/teqbench/packages) → Manage access**). This applies to the entire transitive dependency tree, not just direct dependencies — same as CI.

--- a/docs/reference/workflows/release.md
+++ b/docs/reference/workflows/release.md
@@ -7,7 +7,7 @@
 
 ## Purpose
 
-The Release workflow automates versioning, changelog generation, GitHub Release creation, and npm publishing using Google's [Release Please ↗](https://github.com/googleapis/release-please). It eliminates the need to manually edit version numbers, write changelogs, or create release tags. When a release is created, the package is automatically published to [GitHub Packages ↗](https://github.com/orgs/teqbench/packages).
+The Release workflow automates versioning, changelog generation, GitHub Release creation, and [npm ↗](https://www.npmjs.com/) publishing using Google's [Release Please ↗](https://github.com/googleapis/release-please). It eliminates the need to manually edit version numbers, write changelogs, or create release tags. When a release is created, the package is automatically published to [GitHub Packages ↗](https://github.com/orgs/teqbench/packages).
 
 ---
 
@@ -101,7 +101,7 @@ permissions:
 ### Steps
 
 1. **Checkout code** — Standard checkout (no full history needed).
-2. **Setup Node** — Configures Node from `.nvmrc` with `registry-url: "https://npm.pkg.github.com"` for [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) authentication.
+2. **Setup Node** — Configures [Node.js ↗](https://nodejs.org/) from `.nvmrc` with `registry-url: "https://npm.pkg.github.com"` for [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) authentication.
 3. **Install dependencies** — `npm ci` for deterministic builds. `GITHUB_TOKEN` with `packages: write` handles publishing to the current repo's package, and `packages: read` (inherited) handles installing dependencies.
 4. **Build** — `npm run build` compiles [TypeScript ↗](https://www.typescriptlang.org/) to `dist/`.
 5. **Publish** — `npm publish` with `NODE_AUTH_TOKEN` set to `GITHUB_TOKEN`. The `"files": ["dist"]` field in `package.json` ensures only compiled output is included.

--- a/src/services/base-http.service.ts
+++ b/src/services/base-http.service.ts
@@ -265,7 +265,7 @@ export abstract class TbxNgxHttpService {
     }
 
     /**
-     * Return a custom RxJS retry operator with exponential backoff
+     * Return a custom {@link https://rxjs.dev | RxJS} retry operator with exponential backoff
      *
      * @remarks
      * Only retries transient errors (status codes in
@@ -282,7 +282,7 @@ export abstract class TbxNgxHttpService {
      * Backoff formula: `RETRY_DELAY * 2^(attempt - 1)`
      *
      * @typeParam T - Observable element type.
-     * @returns An RxJS operator function that applies the retry strategy.
+     * @returns An {@link https://rxjs.dev | RxJS} operator function that applies the retry strategy.
      *
      * @public
      */


### PR DESCRIPTION
## Summary

- Fix 45 unlinked or incorrectly linked external technology references across 10 files
- Link all prose mentions of Angular, TypeScript, RxJS, Vitest, ESLint, Prettier, Husky, lint-staged, nvm, npm, Node.js, ng-packagr, TSDoc, API Extractor, Release Please, Conventional Commits, GitHub Packages, Claude Code, and Contributor Covenant
- Fix lint-staged URL (moved from `okonet/lint-staged` to `lint-staged/lint-staged`)
- Remove link from TSDoc section heading in CLAUDE.md (convention: no links in headings)
- Add ↗ to CODE_OF_CONDUCT.md attribution links and PR template
- Add `{@link}` for RxJS in `withRetry()` TSDoc comments

## Test plan

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm test` passes (47/47)
- [x] `/external-link-verification` audit returns zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)