### PR TITLE
docs(ai): fix 7 AI friendliness findings across source and workflow docs

### DIFF
--- a/docs/reference/workflows/ci.md
+++ b/docs/reference/workflows/ci.md
@@ -20,8 +20,6 @@ The CI workflow is the quality gate for the repository. It runs formatting check
 
 ---
 
----
-
 ## Concurrency
 
 ```yaml

--- a/docs/reference/workflows/claude.md
+++ b/docs/reference/workflows/claude.md
@@ -204,4 +204,4 @@ Claude will:
 - **Max turns:** 10 — prevents runaway sessions
 - **Timeout:** 30 minutes — hard cap on execution time
 - **No workflow edits** — Claude should not modify `.github/workflows/*` without explicit instruction (enforced by `CLAUDE.md` conventions)
-- **No release file edits** — Claude should not modify `release-please-config.json`, `.release-please-manifest.json`, `CHANGELOG.md`, or `.badges/*` (enforced by `CLAUDE.md` conventions)
+- **No release file edits** — Claude should not modify `release-please-config.json`, `.release-please-manifest.json`, or `CHANGELOG.md` (enforced by `CLAUDE.md` conventions)

--- a/docs/reference/workflows/dep-compat-check.md
+++ b/docs/reference/workflows/dep-compat-check.md
@@ -45,7 +45,7 @@ No app token needed — this workflow only reads the [npm ↗](https://www.npmjs
 
 ### Configuration
 
-The workflow uses a tracking epic issue. The `EPIC` constant in the workflow file must be set to the issue number during repository setup (see SETUP.md step 8).
+The workflow uses a tracking epic issue. The `EPIC` constant in the workflow file must be set to the issue number during repository setup. Setup documentation is maintained in the foundation repository and is not accessible from this repo.
 
 ### Issue Metadata Format
 

--- a/docs/reference/workflows/dependabot.md
+++ b/docs/reference/workflows/dependabot.md
@@ -59,7 +59,7 @@ Updates action versions used in all workflow files (e.g., `actions/checkout@v4` 
 
 ## Interaction with Pinned Dependencies
 
-Some dependencies are intentionally pinned without caret ranges (see `devDependenciesPinned` in `package.json`):
+Some dependencies are intentionally pinned without caret ranges (see `devDependenciesPinned`, a custom metadata field not consumed by [npm ↗](https://www.npmjs.com/), in `package.json`):
 
 - **[typescript-eslint ↗](https://typescript-eslint.io/)** — pinned without `^` because patch releases have introduced breaking rule changes
 - **`@types/node`** — pinned to `~24.0.0` to match the Node 24 runtime

--- a/docs/reference/workflows/release.md
+++ b/docs/reference/workflows/release.md
@@ -178,6 +178,8 @@ Key settings:
 }
 ```
 
+> The version shown above is an example; the actual value reflects the current release.
+
 Tracks the current released version. Updated automatically by release-please. CI reads this file to generate the version badge.
 
 ---

--- a/src/services/base-http.service.ts
+++ b/src/services/base-http.service.ts
@@ -32,6 +32,7 @@ import type { TbxNgxHttpBodyRequestOptions } from '../models/http-body-request-o
  *
  * @example
  * ```typescript
+ * // UserService is a hypothetical consumer-defined subclass
  * @Injectable({ providedIn: 'root' })
  * export class UserService extends TbxNgxHttpService {
  *     protected override readonly baseUrl = environment.apiUrl;
@@ -44,6 +45,7 @@ import type { TbxNgxHttpBodyRequestOptions } from '../models/http-body-request-o
  *
  * @example
  * ```typescript
+ * // SlowApiService is a hypothetical consumer-defined subclass
  * export class SlowApiService extends TbxNgxHttpService {
  *     protected override readonly baseUrl = environment.apiUrl;
  *     protected override readonly DEFAULT_TIMEOUT = 30_000;


### PR DESCRIPTION
## Summary

- Add placeholder comments to hypothetical class names in `@example` blocks (`UserService`, `SlowApiService`)
- Add stale-snapshot caveat to manifest version in release.md
- Identify `devDependenciesPinned` as a custom metadata field in dependabot.md
- Replace dangling `SETUP.md step 8` reference with external-repo note in dep-compat-check.md
- Remove phantom `.badges/*` reference from claude.md
- Collapse duplicate `---` separator in ci.md

## Test plan

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm test` passes (47/47)
- [x] `/ai-friendliness-verification` audit returns zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)