### PR TITLE
chore(license): update package-lock license to AGPL-3.0-only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@teqbench/tbx-ngx-http",
       "version": "1.0.1",
-      "license": "Apache-2.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "http-status-codes": "^2.3.0"
       },


### PR DESCRIPTION
## Summary
- Update `package-lock.json` license field from `Apache-2.0` to `AGPL-3.0-only` to match the project license

## Test plan
- [x] Verify `npm ci` installs cleanly with updated lock file
- [x] Verify build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)