### PR TITLE
docs(claude): align tbx-models references with domain-entity rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ All exported [TypeScript ↗](https://www.typescriptlang.org/) declarations must
 - `@since` — The package version when the export was first introduced (e.g., "1.0.0"). Allows the docs generator to render version badges and filter by release.
 - `@related` — Cross-reference to a related export, optionally in another `@teqbench` package (e.g., "TbxAuthService" or "@teqbench/tbx-auth#TbxAuthService"). Repeatable — use one `@related` tag per reference.
 - `@usage` — Prose description of when and why to use this export, distinct from `@example` which shows code. Helps the AI generator produce contextual KB articles rather than raw API listings.
-- `@displayName` — Human-friendly label used as the heading in generated docs (e.g., "Base Model" for `TbxModel`). When omitted, the export name is used as-is.
+- `@displayName` — Human-friendly label used as the heading in generated docs (e.g., "Base Domain Entity Model" for `TbxDomainEntityModel`). When omitted, the export name is used as-is.
 - `@order` — Numeric sort hint controlling display sequence. Applied at two levels:
     - Top-level exports: controls display sequence within a `@category` on generated pages.
     - Members (properties, methods): controls display sequence within the parent class/interface page. Members without `@order` are sorted by precedence group (see Member Ordering below), then alphabetically.
@@ -147,7 +147,7 @@ Members (properties, methods): summary line → `@remarks` → `@param` / `@retu
 
 ### Reference Implementation
 
-`@teqbench/tbx-models` (a separate repository) `src/model.ts` is the reference for a fully migrated [TSDoc ↗](https://tsdoc.org) comment on an interface with member-level docs including `@order` tags. `src/index.ts` in that same package is the reference for a `@packageDocumentation` barrel file [TSDoc ↗](https://tsdoc.org) comment. These files are not accessible from this repository — clone `@teqbench/tbx-models` separately to view them.
+`@teqbench/tbx-models` (a separate repository) `src/models/domain-entity.model.ts` is the reference for a fully migrated [TSDoc ↗](https://tsdoc.org) comment on an interface with member-level docs including `@order` tags. `src/index.ts` in that same package is the reference for a `@packageDocumentation` barrel file [TSDoc ↗](https://tsdoc.org) comment. These files are not accessible from this repository — clone `@teqbench/tbx-models` separately to view them.
 
 ### Verification
 


### PR DESCRIPTION
## Summary
- Update `@displayName` example to use `TbxDomainEntityModel` instead of `TbxModel`
- Update reference implementation path from `src/model.ts` to `src/models/domain-entity.model.ts`

## Test plan
- [x] Prettier check passes
- [x] Lint passes
- [x] Typecheck passes
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)