### PR TITLE
chore(deps): add .claude/ to ESLint ignores

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import tsdoc from 'eslint-plugin-tsdoc';
 
 export default tseslint.config(
     {
-        ignores: ['coverage/', 'dist/', 'node_modules/'],
+        ignores: ['.claude/', 'coverage/', 'dist/', 'node_modules/'],
     },
     ...tseslint.configs.recommended,
     ...angular.configs.tsRecommended,


### PR DESCRIPTION
## Summary

- Add `.claude/` to ESLint ignores to prevent stale worktree files from breaking lint

Closes #49

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm run test:coverage` passes
- [x] `npm run typecheck` passes
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)