### PR TITLE
chore(lint): exclude .shared-skills from eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import tsdoc from 'eslint-plugin-tsdoc';
 
 export default tseslint.config(
     {
-        ignores: ['.claude/', 'coverage/', 'dist/', 'node_modules/'],
+        ignores: ['.claude/', '.shared-skills/', 'coverage/', 'dist/', 'node_modules/'],
     },
     ...tseslint.configs.recommended,
     ...angular.configs.tsRecommended,


### PR DESCRIPTION
## Summary
Add `.shared-skills/` to the ESLint ignores array. The submodule contains third-party skill files (including `.js` templates) that are not part of the TypeScript project, causing ESLint parse errors.

## Test plan
- [ ] `npm run lint` passes without errors from `.shared-skills/` files

Generated with [Claude Code](https://claude.com/claude-code)
