### PR TITLE
release: onboard tbx-ngx-http to docs pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,64 @@
 
 ![Build Status](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-ngx-http-main-build-status.json) ![Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-ngx-http-main-tests.json) ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-ngx-http-main-coverage.json) ![Version](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-ngx-http-main-version.json) ![Build Number](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-ngx-http-main-build-number.json)
 
-> Base HTTP communication services and resilience constants for [Angular ↗](https://angular.dev/). Provides automatic retries with exponential backoff, timeout handling, and consistent URL resolution for feature services.
+> Resilient base HTTP service for [Angular ↗](https://angular.dev) with automatic retry on transient failures, configurable timeouts, and typed request options — one abstract class that feature services extend to gain consistent resilience without per-call boilerplate.
+
+<details>
+<summary><strong>Table of contents</strong></summary>
+
+- [Overview](#overview)
+- [At a glance](#at-a-glance)
+- [When to use](#when-to-use)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Concepts](#concepts)
+- [API Reference](#api-reference)
+- [Accessibility](#accessibility)
+- [Compatibility](#compatibility)
+- [Versioning & releases](#versioning--releases)
+- [Contributing](#contributing)
+- [Security](#security)
+- [Feedback](#feedback)
+- [License](#license)
+
+</details>
+
+## Overview
+
+`@teqbench/tbx-ngx-http` provides an abstract base HTTP service for [Angular ↗](https://angular.dev) feature services. Rather than re-implementing retry, timeout, URL resolution, and default-header logic in every service that talks to the backend, feature services extend `TbxNgxHttpService` and inherit a consistent resilience envelope over [`HttpClient` ↗](https://angular.dev/api/common/http/HttpClient).
+
+The service exposes typed `get`, `post`, `put`, `patch`, and `delete` methods backed by two dedicated option interfaces — `TbxNgxHttpRequestOptions` for non-body methods (params + headers) and `TbxNgxHttpBodyRequestOptions` for body methods (headers only). Only GET requests go through the retry operator; mutating methods intentionally skip retry because POST/PUT/PATCH/DELETE are not safely repeatable on transient failure. Timeouts apply to every method uniformly.
+
+The retry strategy uses exponential backoff (`RETRY_DELAY * 2^(attempt - 1)`) and consults a fixed set of retryable statuses — `0` (network error), `408`, `429`, `500`, `502`, `503`, `504`. Non-retryable HTTP errors (4xx client errors other than 408/429) are re-thrown immediately. Non-`HttpErrorResponse` failures, including [`TimeoutError` ↗](https://rxjs.dev/api/index/class/TimeoutError) from the upstream operator, are always retried on GET. All four resilience parameters (timeout, retry count, retry delay, retryable statuses) are also exported as standalone constants for consumers building custom retry pipelines outside of `TbxNgxHttpService`.
+
+The package supports [Angular ↗](https://angular.dev) 19, 20, and 21, carries no `@teqbench` runtime dependencies, and depends only on [`http-status-codes` ↗](https://github.com/prettymuchbryce/http-status-codes) at runtime for the canonical status-code enum.
+
+## At a glance
+
+- **Resilient base service** — abstract `TbxNgxHttpService` that feature services extend to inherit retry, timeout, URL resolution, and default headers.
+- **GET retry with exponential backoff** — transient failures (network errors, 408, 429, 5xx) are retried with delay `RETRY_DELAY * 2^(attempt - 1)`.
+- **Configurable timeout** — every request is bounded by `DEFAULT_TIMEOUT` (10s default); subclasses override the class property to tune per service.
+- **Idempotency-aware retry** — only GET retries. POST, PUT, PATCH, and DELETE skip retry to avoid duplicate writes on transient failure.
+- **Typed request options** — `TbxNgxHttpRequestOptions` for params + headers (non-body methods); `TbxNgxHttpBodyRequestOptions` for body methods.
+- **Per-subclass override** — `DEFAULT_TIMEOUT`, `RETRY_COUNT`, and `RETRY_DELAY` are protected class properties — redeclare in a subclass to override.
+- **Exposed resilience constants** — `TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS`, `RETRY_COUNT`, `RETRY_DELAY_MS`, and `RETRYABLE_STATUSES` are exported for custom pipelines.
+- **Default headers** — `Accept: application/json` is set by default; callers providing `options.headers` replace the set entirely, not merge.
+- **URL resolution** — relative paths are joined to the subclass-provided `baseUrl` with consistent slash handling.
+- **Broad [Angular ↗](https://angular.dev) peer range** — supports [Angular ↗](https://angular.dev) 19, 20, and 21; no `@teqbench` runtime dependencies.
+
+## When to use
+
+Reach for this package when your [Angular ↗](https://angular.dev) application needs:
+
+- Consistent HTTP resilience (retry + timeout) across multiple feature services without duplicating the [RxJS ↗](https://rxjs.dev) operators in every call.
+- A typed, ergonomic surface over [`HttpClient` ↗](https://angular.dev/api/common/http/HttpClient) for GET/POST/PUT/PATCH/DELETE with request-option interfaces that match each method's body semantics.
+- A single place to tune retry count, backoff delay, and the set of retryable status codes.
+
+Skip it when you're making one-off HTTP calls and don't need resilience beyond [`HttpClient` ↗](https://angular.dev/api/common/http/HttpClient) defaults — direct use is simpler.
 
 ## Installation
 
-Configure npm to use [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) for the `@teqbench` scope:
+Configure [npm ↗](https://www.npmjs.com) to use [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) for the `@teqbench` scope:
 
 ```bash
 echo "@teqbench:registry=https://npm.pkg.github.com" >> .npmrc
@@ -18,7 +71,15 @@ Install the package:
 npm install @teqbench/tbx-ngx-http
 ```
 
+### Prerequisites
+
+The consuming application must provide [`HttpClient` ↗](https://angular.dev/api/common/http/HttpClient) through its [Angular ↗](https://angular.dev) DI — typically via [`provideHttpClient()` ↗](https://angular.dev/api/common/http/provideHttpClient) in `app.config.ts`. `TbxNgxHttpService` injects `HttpClient` directly.
+
 ## Usage
+
+### Extend the base service
+
+Create a feature service by extending `TbxNgxHttpService`, providing a `baseUrl`, and exposing typed methods.
 
 ```typescript
 import { Injectable } from '@angular/core';
@@ -33,15 +94,84 @@ export class UserService extends TbxNgxHttpService {
         return this.get<User>(`users/${id}`);
     }
 
+    listUsers() {
+        return this.get<User[]>('users', { params: { page: '1' } });
+    }
+
     createUser(data: CreateUserDto) {
         return this.post<User>('users', data);
+    }
+
+    updateUser(id: string, data: UpdateUserDto) {
+        return this.put<User>(`users/${id}`, data);
+    }
+
+    deleteUser(id: string) {
+        return this.delete<void>(`users/${id}`);
     }
 }
 ```
 
+### Tune resilience per feature service
+
+Redeclare the protected class properties in a subclass to override the defaults for one service.
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class SlowApiService extends TbxNgxHttpService {
+    protected override readonly baseUrl = environment.slowApiUrl;
+    protected override readonly DEFAULT_TIMEOUT = 30_000;
+    protected override readonly RETRY_COUNT = 5;
+    protected override readonly RETRY_DELAY = 2_000;
+}
+```
+
+### Use the resilience constants in a custom pipeline
+
+Import the constants directly when building retry logic outside of `TbxNgxHttpService`.
+
+```typescript
+import { TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS, TBX_NGX_HTTP_RETRYABLE_STATUSES } from '@teqbench/tbx-ngx-http';
+import { HttpErrorResponse } from '@angular/common/http';
+import { retry, timeout, throwError, timer } from 'rxjs';
+
+this.http.get<User[]>('/api/users').pipe(
+    timeout(TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS),
+    retry({
+        count: 3,
+        delay: (error) => {
+            if (error instanceof HttpErrorResponse && !TBX_NGX_HTTP_RETRYABLE_STATUSES.has(error.status)) {
+                return throwError(() => error);
+            }
+            return timer(1_000);
+        },
+    })
+);
+```
+
+### Headers: replace, don't merge
+
+Passing `options.headers` replaces the default `Accept: application/json` entirely — the caller owns the full header set.
+
+```typescript
+this.get<Blob>('reports/monthly.pdf', {
+    headers: new HttpHeaders({ Accept: 'application/pdf' }),
+});
+```
+
+## Concepts
+
+- **Base HTTP service** — the abstract `TbxNgxHttpService` that consumers extend to gain timeout, retry, URL resolution, and default-header behavior over [Angular ↗](https://angular.dev) [`HttpClient` ↗](https://angular.dev/api/common/http/HttpClient).
+- **Feature service** — a consumer-defined subclass of `TbxNgxHttpService` that provides a `baseUrl` and exposes typed methods for a specific backend surface.
+- **Resilience constants** — exported default values for timeout, retry count, retry delay, and the set of retryable statuses; can be imported directly when building custom pipelines.
+- **Retryable status** — one of `0` (network error), `408`, `429`, `500`, `502`, `503`, `504` — transient failures worth retrying with backoff.
+- **Idempotency-aware retry** — the rule that only GET requests retry automatically; POST, PUT, PATCH, and DELETE skip retry to prevent duplicate writes on transient failure.
+- **Exponential backoff** — a retry delay strategy where the wait doubles on each attempt — `delay = RETRY_DELAY * 2^(attempt - 1)`.
+- **Per-subclass override** — the pattern of redeclaring a protected class property (`DEFAULT_TIMEOUT`, `RETRY_COUNT`, `RETRY_DELAY`) in a subclass to change resilience behavior for one feature service.
+
 ## API Reference
 
-### `TbxNgxHttpService` (abstract class)
+### TbxNgxHttpService (abstract class)
 
 Abstract base class for feature services. Provides typed HTTP methods with built-in resilience.
 
@@ -53,30 +183,72 @@ Abstract base class for feature services. Provides typed HTTP methods with built
 | `patch`  | `patch<T>(path: string, body: unknown, options?: TbxNgxHttpBodyRequestOptions): Observable<T>` | No      |
 | `delete` | `delete<T>(path: string, options?: TbxNgxHttpRequestOptions): Observable<T>`                   | No      |
 
+Overridable protected properties (redeclare in a subclass to change behavior):
+
+| Property          | Type          | Default                           | Description                                              |
+| ----------------- | ------------- | --------------------------------- | -------------------------------------------------------- |
+| `baseUrl`         | `string`      | — (abstract, must be provided)    | API root URL.                                            |
+| `DEFAULT_TIMEOUT` | `number`      | `TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS` | Request timeout in milliseconds.                         |
+| `RETRY_COUNT`     | `number`      | `TBX_NGX_HTTP_RETRY_COUNT`        | Retry attempts on GET (applies to GET only).             |
+| `RETRY_DELAY`     | `number`      | `TBX_NGX_HTTP_RETRY_DELAY_MS`     | Base delay in ms for exponential backoff.                |
+| `defaultHeaders`  | `HttpHeaders` | `Accept: application/json`        | Applied when the caller does not pass `options.headers`. |
+
+### TbxNgxHttpRequestOptions
+
+Options for non-body methods (`get`, `delete`).
+
+| Property   | Type                                   | Description                             |
+| ---------- | -------------------------------------- | --------------------------------------- |
+| `params?`  | `HttpParams \| Record<string, string>` | Query string parameters.                |
+| `headers?` | `HttpHeaders`                          | Replaces `defaultHeaders` when present. |
+
+### TbxNgxHttpBodyRequestOptions
+
+Options for body methods (`post`, `put`, `patch`).
+
+| Property   | Type          | Description                             |
+| ---------- | ------------- | --------------------------------------- |
+| `headers?` | `HttpHeaders` | Replaces `defaultHeaders` when present. |
+
 ### Constants
 
-| Constant                          | Default  | Description                                        |
-| --------------------------------- | -------- | -------------------------------------------------- |
-| `TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS` | `10_000` | Request timeout in milliseconds                    |
-| `TBX_NGX_HTTP_RETRY_COUNT`        | `2`      | Number of retry attempts for GET requests          |
-| `TBX_NGX_HTTP_RETRY_DELAY_MS`     | `1_000`  | Base delay for exponential backoff                 |
-| `TBX_NGX_HTTP_RETRYABLE_STATUSES` | `Set`    | Status codes eligible for retry (0, 408, 429, 5xx) |
+| Constant                          | Default  | Description                                                         |
+| --------------------------------- | -------- | ------------------------------------------------------------------- |
+| `TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS` | `10_000` | Request timeout in milliseconds.                                    |
+| `TBX_NGX_HTTP_RETRY_COUNT`        | `2`      | Number of retry attempts for GET requests.                          |
+| `TBX_NGX_HTTP_RETRY_DELAY_MS`     | `1_000`  | Base delay in milliseconds for exponential backoff.                 |
+| `TBX_NGX_HTTP_RETRYABLE_STATUSES` | `Set`    | Status codes eligible for retry: `0, 408, 429, 500, 502, 503, 504`. |
+
+## Accessibility
+
+- This package provides services, constants, and type interfaces only. It has no direct UI surface, no rendered DOM, and no keyboard, focus, color, or motion considerations. Accessibility for any UI that surfaces HTTP errors, loading states, or retry progress is owned by the consuming application.
 
 ## Compatibility
 
-| Dependency                                      | Version                       |
-| ----------------------------------------------- | ----------------------------- |
-| [Angular ↗](https://angular.dev/)               | ^19.0.0 \| ^20.0.0 \| ^21.0.0 |
-| [RxJS ↗](https://rxjs.dev/)                     | ^7.0.0                        |
-| [TypeScript ↗](https://www.typescriptlang.org/) | ~5.9.0                        |
-| [Node.js ↗](https://nodejs.org/)                | >=24.0.0                      |
+| Dependency                                                                  | Version                       |
+| --------------------------------------------------------------------------- | ----------------------------- |
+| [Angular ↗](https://angular.dev)                                            | ^19.0.0 \| ^20.0.0 \| ^21.0.0 |
+| [RxJS ↗](https://rxjs.dev)                                                  | ^7.0.0                        |
+| [http-status-codes ↗](https://github.com/prettymuchbryce/http-status-codes) | ^2.3.0                        |
+| [TypeScript ↗](https://www.typescriptlang.org)                              | ~5.9.0                        |
+| [Node.js ↗](https://nodejs.org)                                             | >=24.0.0                      |
+
+## Versioning & releases
+
+This package follows [Semantic Versioning ↗](https://semver.org). Versions and changelog entries are produced automatically by [Release Please ↗](https://github.com/googleapis/release-please) from [Conventional Commits ↗](https://www.conventionalcommits.org) on `main`. See [CHANGELOG.md](CHANGELOG.md) for the full release history.
+
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) authentication, branch conventions, commit format, and the PR workflow.
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for the supported-version policy and how to report a vulnerability privately.
 
 ## Feedback
 
-Found a bug or have an idea for a new feature? Open an issue using one of the provided templates:
-
-- [Bug Report](https://github.com/teqbench/tbx-ngx-http/issues/new?template=bug_report.md)
-- [Feature Request](https://github.com/teqbench/tbx-ngx-http/issues/new?template=feature_request.md)
+- [Report a bug ↗](https://github.com/teqbench/tbx-ngx-http/issues/new?template=bug_report.md)
+- [Request a feature ↗](https://github.com/teqbench/tbx-ngx-http/issues/new?template=feature_request.md)
 
 ## License
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,3 @@
+# Accessibility
+
+- This package provides services, constants, and type interfaces only. It has no direct UI surface, no rendered DOM, and no keyboard, focus, color, or motion considerations. Accessibility for any UI that surfaces HTTP errors, loading states, or retry progress is owned by the consuming application.

--- a/docs/concepts.yml
+++ b/docs/concepts.yml
@@ -1,0 +1,15 @@
+# Glossary rendered in the README "Concepts" section.
+- term: Base HTTP service
+  definition: The abstract TbxNgxHttpService that consumers extend to gain timeout, retry, URL resolution, and default-header behavior over Angular HttpClient.
+- term: Feature service
+  definition: A consumer-defined subclass of TbxNgxHttpService that provides a baseUrl and exposes typed methods for a specific backend surface.
+- term: Resilience constants
+  definition: Exported default values for timeout, retry count, retry delay, and the set of retryable statuses; can be imported directly when building custom pipelines.
+- term: Retryable status
+  definition: One of 0 (network error), 408, 429, 500, 502, 503, 504 — transient failures worth retrying with backoff.
+- term: Idempotency-aware retry
+  definition: The rule that only GET requests retry automatically; POST, PUT, PATCH, and DELETE skip retry to prevent duplicate writes on transient failure.
+- term: Exponential backoff
+  definition: A retry delay strategy where the wait doubles on each attempt — delay = RETRY_DELAY * 2^(attempt - 1).
+- term: Per-subclass override
+  definition: The pattern of redeclaring a protected class property (DEFAULT_TIMEOUT, RETRY_COUNT, RETRY_DELAY) in a subclass to change resilience behavior for one feature service.

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -1,0 +1,21 @@
+# Short, scannable feature bullets rendered in the README "At a glance" section.
+- name: Resilient base service
+  summary: Abstract TbxNgxHttpService that feature services extend to inherit retry, timeout, URL resolution, and default headers.
+- name: GET retry with exponential backoff
+  summary: Transient failures (network errors, 408, 429, 5xx) are retried with delay RETRY_DELAY * 2^(attempt - 1).
+- name: Configurable timeout
+  summary: Every request is bounded by DEFAULT_TIMEOUT (10s default); subclasses override the class property to tune per service.
+- name: Idempotency-aware retry
+  summary: Only GET retries. POST, PUT, PATCH, and DELETE skip retry to avoid duplicate writes on transient failure.
+- name: Typed request options
+  summary: TbxNgxHttpRequestOptions for params + headers (non-body methods); TbxNgxHttpBodyRequestOptions for body methods.
+- name: Per-subclass override
+  summary: DEFAULT_TIMEOUT, RETRY_COUNT, and RETRY_DELAY are protected class properties — redeclare in a subclass to override.
+- name: Exposed resilience constants
+  summary: TBX_NGX_HTTP_DEFAULT_TIMEOUT_MS, RETRY_COUNT, RETRY_DELAY_MS, and RETRYABLE_STATUSES are exported for custom pipelines.
+- name: Default headers
+  summary: Accept application/json is set by default; callers providing options.headers replace the set entirely, not merge.
+- name: URL resolution
+  summary: Relative paths are joined to the subclass-provided baseUrl with consistent slash handling.
+- name: Broad Angular peer range
+  summary: Supports Angular 19, 20, and 21; no @teqbench runtime dependencies.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,23 @@
+---
+tagline: Resilient base HTTP service for [Angular ↗](https://angular.dev) with automatic retry on transient failures, configurable timeouts, and typed request options — one abstract class that feature services extend to gain consistent resilience without per-call boilerplate.
+---
+
+## Overview
+
+`@teqbench/tbx-ngx-http` provides an abstract base HTTP service for [Angular ↗](https://angular.dev) feature services. Rather than re-implementing retry, timeout, URL resolution, and default-header logic in every service that talks to the backend, feature services extend `TbxNgxHttpService` and inherit a consistent resilience envelope over [`HttpClient` ↗](https://angular.dev/api/common/http/HttpClient).
+
+The service exposes typed `get`, `post`, `put`, `patch`, and `delete` methods backed by two dedicated option interfaces — `TbxNgxHttpRequestOptions` for non-body methods (params + headers) and `TbxNgxHttpBodyRequestOptions` for body methods (headers only). Only GET requests go through the retry operator; mutating methods intentionally skip retry because POST/PUT/PATCH/DELETE are not safely repeatable on transient failure. Timeouts apply to every method uniformly.
+
+The retry strategy uses exponential backoff (`RETRY_DELAY * 2^(attempt - 1)`) and consults a fixed set of retryable statuses — `0` (network error), `408`, `429`, `500`, `502`, `503`, `504`. Non-retryable HTTP errors (4xx client errors other than 408/429) are re-thrown immediately. Non-`HttpErrorResponse` failures, including [`TimeoutError` ↗](https://rxjs.dev/api/index/class/TimeoutError) from the upstream operator, are always retried on GET. All four resilience parameters (timeout, retry count, retry delay, retryable statuses) are also exported as standalone constants for consumers building custom retry pipelines outside of `TbxNgxHttpService`.
+
+The package supports [Angular ↗](https://angular.dev) 19, 20, and 21, carries no `@teqbench` runtime dependencies, and depends only on [`http-status-codes` ↗](https://github.com/prettymuchbryce/http-status-codes) at runtime for the canonical status-code enum.
+
+## When to use
+
+Reach for this package when your [Angular ↗](https://angular.dev) application needs:
+
+- Consistent HTTP resilience (retry + timeout) across multiple feature services without duplicating the [RxJS ↗](https://rxjs.dev) operators in every call.
+- A typed, ergonomic surface over [`HttpClient` ↗](https://angular.dev/api/common/http/HttpClient) for GET/POST/PUT/PATCH/DELETE with request-option interfaces that match each method's body semantics.
+- A single place to tune retry count, backoff delay, and the set of retryable status codes.
+
+Skip it when you're making one-off HTTP calls and don't need resilience beyond [`HttpClient` ↗](https://angular.dev/api/common/http/HttpClient) defaults — direct use is simpler.

--- a/ng-package.json
+++ b/ng-package.json
@@ -4,5 +4,12 @@
   "allowedNonPeerDependencies": ["http-status-codes"],
   "lib": {
     "entryFile": "src/index.ts"
-  }
+  },
+  "assets": [
+    {
+      "input": "docs",
+      "glob": "*.{md,yml}",
+      "output": "docs"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
Release PR #65 (docs pipeline onboarding for tbx-ngx-http) to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)