### PR TITLE
fix(ci): pin reusable workflows to @v2.9.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: teqbench/.github/.github/workflows/ci.yml@v2.6.0
+    uses: teqbench/.github/.github/workflows/ci.yml@v2.9.3
     with:
       gist-id: ${{ vars.GIST_ID }}
     secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,5 +24,5 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
-    uses: teqbench/.github/.github/workflows/claude.yml@v2.6.0
+    uses: teqbench/.github/.github/workflows/claude.yml@v2.9.3
     secrets: inherit

--- a/.github/workflows/dep-compat-check.yml
+++ b/.github/workflows/dep-compat-check.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check:
-    uses: teqbench/.github/.github/workflows/dep-compat-check.yml@v2.6.0
+    uses: teqbench/.github/.github/workflows/dep-compat-check.yml@v2.9.3
     with:
       epic-issue-number: 1
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   release:
-    uses: teqbench/.github/.github/workflows/release.yml@v2.6.0
+    uses: teqbench/.github/.github/workflows/release.yml@v2.9.3
     secrets: inherit

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   sync:
-    uses: teqbench/.github/.github/workflows/sync.yml@v2.6.0
+    uses: teqbench/.github/.github/workflows/sync.yml@v2.9.3
     secrets: inherit


### PR DESCRIPTION
Catches up to the latest `teqbench/.github` tag.

No package code changes — workflow files don't ship in the published package tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)