### PR TITLE
fix(changelog): strip broken at-mention autolinks from history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@
 
 ### Bug Fixes
 
-* **ci:** pin reusable workflows to [@v2](https://github.com/v2).9.3 ([d743152](https://github.com/teqbench/tbx-ngx-http/commit/d743152c47349cf8035df6382488778262847d4f)), closes [#28](https://github.com/teqbench/tbx-ngx-http/issues/28)
+* **ci:** pin reusable workflows to v2.9.3 ([d743152](https://github.com/teqbench/tbx-ngx-http/commit/d743152c47349cf8035df6382488778262847d4f)), closes [#28](https://github.com/teqbench/tbx-ngx-http/issues/28)
 
 ## [1.2.1](https://github.com/teqbench/tbx-ngx-http/compare/v1.2.0...v1.2.1) (2026-05-09)
 
 
 ### Bug Fixes
 
-* **ci:** pin reusable workflows to [@v2](https://github.com/v2).6.0 ([35b86d6](https://github.com/teqbench/tbx-ngx-http/commit/35b86d67d1229b78e8b99d623ea9afb370a998a3))
+* **ci:** pin reusable workflows to v2.6.0 ([35b86d6](https://github.com/teqbench/tbx-ngx-http/commit/35b86d67d1229b78e8b99d623ea9afb370a998a3))
 
 ## [1.2.0](https://github.com/teqbench/tbx-ngx-http/compare/v1.1.0...v1.2.0) (2026-05-04)
 
@@ -31,7 +31,7 @@
 * **docs:** list actual emitted APF entry-point keys ([178e667](https://github.com/teqbench/tbx-ngx-http/commit/178e6676933e46f96f40a6e0c832e412b48e83f8))
 * **docs:** normalize external doc URLs to no trailing slash ([f7504d4](https://github.com/teqbench/tbx-ngx-http/commit/f7504d4ae8ee3bf17832dbebd4c0cf390318ed52))
 * **docs:** note central Renovate dependency updates in CLAUDE.md ([69f82de](https://github.com/teqbench/tbx-ngx-http/commit/69f82de7c3bd7e8e794e229f1570c3f19e997c0d))
-* **docs:** note that [@returns](https://github.com/returns) is omitted for void returns ([2aa9308](https://github.com/teqbench/tbx-ngx-http/commit/2aa93089f7375cbc1d73bec984891540129db16b))
+* **docs:** note that returns is omitted for void returns ([2aa9308](https://github.com/teqbench/tbx-ngx-http/commit/2aa93089f7375cbc1d73bec984891540129db16b))
 * **docs:** remove md files now provided by teqbench/.github ([50e773d](https://github.com/teqbench/tbx-ngx-http/commit/50e773d08b8f50d1ea41dab30813469673589f31))
 * **docs:** use vertical list for TSDoc tag ordering ([c25f169](https://github.com/teqbench/tbx-ngx-http/commit/c25f1691c92d91ad583acd05d9966767af016e1f))
 * package updates, CLAUDE.md alignment, docs cleanup ([1313323](https://github.com/teqbench/tbx-ngx-http/commit/13133230f4d48c98a5c5e3a3511ce1fde7722a04))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,17 @@ Follow **[Conventional Commits ↗](https://www.conventionalcommits.org)** stric
 - `refactor(scope): ...` — Refactor
 - `chore(scope): ...` — Maintenance
 
+### No Bare At-Prefixed Tokens
+
+Do not write the at-symbol followed by a non-slashed identifier in commit subjects or bodies. The release-please changelog renderer ([conventional-changelog-conventionalcommits ↗](https://github.com/conventional-changelog/conventional-changelog) v6 `writerOpts.transform`) rewrites such tokens as broken GitHub user-mention links, splitting version strings into links to non-existent users.
+
+- Version refs: write `v2.9.3`, not preceded by the at-symbol.
+- Scope/org refs in prose: write `teqbench`, not preceded by the at-symbol.
+- TSDoc tag refs in prose: write `related`, `example`, `since`, `category`, `returns`, `link` — not preceded by the at-symbol.
+- Fully-qualified scoped package paths that contain a forward slash remain safe; the renderer short-circuits them.
+
+Markdown formatting does not escape this rewrite: backticks and code spans in commit messages do not protect.
+
 ## Branching & Workflow
 
 - `main` — Production. Only receives merges from `release/*`, `hotfix/*`, or `release-please--*` branches.


### PR DESCRIPTION
## Summary

- Strip broken GitHub user-mention autolinks injected by release-please's changelog renderer from CHANGELOG.md.
- Add a CLAUDE.md section codifying the rule that bare at-prefixed tokens must not appear in commit subjects or bodies, with safe-form guidance for scoped package paths.
- Advance the `.shared-skills` submodule pointer to latest `main` to pull in waves 0 and 1 changelog fixes.

## Root cause

release-please uses `conventional-changelog-conventionalcommits@^6.0.0`. Its `writerOpts.transform` callback rewrites bare at-prefixed identifiers in commit subjects as GitHub user-mention links. The match terminates at the first `.` or `/`, so a token like `v2.9.3` written with a leading at-symbol is rendered as a broken link to a non-existent `v2` user with `.9.3` left as bare text. The link wrapping is hardcoded; no release-please or preset configuration disables it.

## Wave 2 of org-wide remediation

| Wave | Repo | Status |
|---|---|---|
| canary | tbx-mat-banners | merged to dev, release deferred to wave 4 |
| 0 | teqbench.dev.misc-skills | released to main |
| 1 | teqbench.dev.shared-skills | released to main |
| **2** | **tbx-models, tbx-ngx-errors, tbx-ngx-http, tbx-mat-icons (this PR)** | **in progress** |
| 3 | tbx-mat-severity-theme | pending |
| 4 | tbx-mat-{notifications, banners, bottom-sheets, dialogs} | pending |
| 5 | teqbench.app.{website, liists.webapp, tradingtoolbox.webapp} | pending |
| 6 | teqbench.dev.templates.tbx-package | pending |

## Test plan

- [ ] Reviewer confirms diff: CHANGELOG.md unwraps, 1 CLAUDE.md addition, 1 `.shared-skills` pointer advance.
- [ ] Merge to `dev`; carry to `main` via `release/*`; release-please opens its PR.
- [ ] Reviewer confirms the new release-please section does NOT contain `[at-x](...)` autolinks.
- [ ] Merge release-please PR; new tag is the artifact the website ingests.